### PR TITLE
Recalculate pit strat

### DIFF
--- a/FCalcACC/Form1.Designer.cs
+++ b/FCalcACC/Form1.Designer.cs
@@ -124,7 +124,7 @@
             // label_fuel_L
             // 
             label_fuel_L.AutoSize = true;
-            label_fuel_L.Location = new Point(41, 145);
+            label_fuel_L.Location = new Point(105, 142);
             label_fuel_L.Name = "label_fuel_L";
             label_fuel_L.Size = new Size(56, 15);
             label_fuel_L.TabIndex = 19;
@@ -132,19 +132,19 @@
             // 
             // textBox_fuel_per_lap
             // 
-            textBox_fuel_per_lap.Location = new Point(103, 142);
+            textBox_fuel_per_lap.Location = new Point(45, 139);
             textBox_fuel_per_lap.MaxLength = 4;
             textBox_fuel_per_lap.Name = "textBox_fuel_per_lap";
             textBox_fuel_per_lap.Size = new Size(55, 23);
             textBox_fuel_per_lap.TabIndex = 18;
             textBox_fuel_per_lap.Text = "0.0";
             textBox_fuel_per_lap.TextAlign = HorizontalAlignment.Center;
-            textBox_fuel_per_lap.KeyPress += textBox_fuel_per_lap_KeyPress;
+            textBox_fuel_per_lap.KeyPress += TextBox_fuel_per_lap_KeyPress;
             // 
             // label_lap_time_sec
             // 
             label_lap_time_sec.AutoSize = true;
-            label_lap_time_sec.Location = new Point(285, 68);
+            label_lap_time_sec.Location = new Point(358, 68);
             label_lap_time_sec.Name = "label_lap_time_sec";
             label_lap_time_sec.Size = new Size(28, 15);
             label_lap_time_sec.TabIndex = 17;
@@ -153,7 +153,7 @@
             // label_lap_time_min
             // 
             label_lap_time_min.AutoSize = true;
-            label_lap_time_min.Location = new Point(206, 68);
+            label_lap_time_min.Location = new Point(254, 68);
             label_lap_time_min.Name = "label_lap_time_min";
             label_lap_time_min.Size = new Size(28, 15);
             label_lap_time_min.TabIndex = 16;
@@ -161,30 +161,30 @@
             // 
             // textBox_lap_time_sec
             // 
-            textBox_lap_time_sec.Location = new Point(313, 65);
+            textBox_lap_time_sec.Location = new Point(290, 65);
             textBox_lap_time_sec.MaxLength = 6;
             textBox_lap_time_sec.Name = "textBox_lap_time_sec";
-            textBox_lap_time_sec.Size = new Size(73, 23);
+            textBox_lap_time_sec.Size = new Size(64, 23);
             textBox_lap_time_sec.TabIndex = 15;
             textBox_lap_time_sec.Text = "0.000";
             textBox_lap_time_sec.TextAlign = HorizontalAlignment.Center;
-            textBox_lap_time_sec.KeyPress += textBox_lap_time_sec_KeyPress;
+            textBox_lap_time_sec.KeyPress += TextBox_lap_time_sec_KeyPress;
             // 
             // textBox_lap_time_min
             // 
-            textBox_lap_time_min.Location = new Point(232, 65);
-            textBox_lap_time_min.MaxLength = 1;
+            textBox_lap_time_min.Location = new Point(206, 65);
+            textBox_lap_time_min.MaxLength = 2;
             textBox_lap_time_min.Name = "textBox_lap_time_min";
             textBox_lap_time_min.Size = new Size(46, 23);
             textBox_lap_time_min.TabIndex = 14;
             textBox_lap_time_min.Text = "0";
             textBox_lap_time_min.TextAlign = HorizontalAlignment.Center;
-            textBox_lap_time_min.KeyPress += textBox_lap_time_min_KeyPress;
+            textBox_lap_time_min.KeyPress += TextBox_lap_time_min_KeyPress;
             // 
             // label_race_min
             // 
             label_race_min.AutoSize = true;
-            label_race_min.Location = new Point(103, 68);
+            label_race_min.Location = new Point(162, 68);
             label_race_min.Name = "label_race_min";
             label_race_min.Size = new Size(28, 15);
             label_race_min.TabIndex = 13;
@@ -193,7 +193,7 @@
             // label_race_h
             // 
             label_race_h.AutoSize = true;
-            label_race_h.Location = new Point(10, 68);
+            label_race_h.Location = new Point(70, 68);
             label_race_h.Name = "label_race_h";
             label_race_h.Size = new Size(14, 15);
             label_race_h.TabIndex = 12;
@@ -201,25 +201,25 @@
             // 
             // textBox_race_min
             // 
-            textBox_race_min.Location = new Point(135, 65);
+            textBox_race_min.Location = new Point(103, 65);
             textBox_race_min.MaxLength = 2;
             textBox_race_min.Name = "textBox_race_min";
             textBox_race_min.Size = new Size(55, 23);
             textBox_race_min.TabIndex = 11;
             textBox_race_min.Text = "0";
             textBox_race_min.TextAlign = HorizontalAlignment.Center;
-            textBox_race_min.KeyPress += textBox_race_min_KeyPress;
+            textBox_race_min.KeyPress += TextBox_race_min_KeyPress;
             // 
             // textBox_race_h
             // 
-            textBox_race_h.Location = new Point(27, 65);
+            textBox_race_h.Location = new Point(10, 65);
             textBox_race_h.MaxLength = 2;
             textBox_race_h.Name = "textBox_race_h";
             textBox_race_h.Size = new Size(55, 23);
             textBox_race_h.TabIndex = 10;
             textBox_race_h.Text = "0";
             textBox_race_h.TextAlign = HorizontalAlignment.Center;
-            textBox_race_h.KeyPress += textBox_race_h_KeyPress;
+            textBox_race_h.KeyPress += TextBox_race_h_KeyPress;
             // 
             // label_formation
             // 
@@ -316,7 +316,7 @@
             checkBox_max_stint.Size = new Size(15, 14);
             checkBox_max_stint.TabIndex = 0;
             checkBox_max_stint.UseVisualStyleBackColor = true;
-            checkBox_max_stint.Click += checkBox_max_stint_Click;
+            checkBox_max_stint.Click += CheckBox_max_stint_Click;
             // 
             // comboBox_pit_options
             // 
@@ -325,7 +325,7 @@
             comboBox_pit_options.Name = "comboBox_pit_options";
             comboBox_pit_options.Size = new Size(155, 23);
             comboBox_pit_options.TabIndex = 12;
-            comboBox_pit_options.SelectedIndexChanged += comboBox_pit_options_SelectedIndexChanged;
+            comboBox_pit_options.SelectedIndexChanged += ComboBox_pit_options_SelectedIndexChanged;
             // 
             // textBox_max_stint
             // 
@@ -333,11 +333,11 @@
             textBox_max_stint.Location = new Point(272, 76);
             textBox_max_stint.MaxLength = 2;
             textBox_max_stint.Name = "textBox_max_stint";
-            textBox_max_stint.Size = new Size(114, 23);
+            textBox_max_stint.Size = new Size(82, 23);
             textBox_max_stint.TabIndex = 17;
             textBox_max_stint.Text = "0";
             textBox_max_stint.TextAlign = HorizontalAlignment.Center;
-            textBox_max_stint.KeyPress += textBox_max_stint_KeyPress;
+            textBox_max_stint.KeyPress += TextBox_max_stint_KeyPress;
             // 
             // label_pits_count
             // 
@@ -353,7 +353,7 @@
             // label_max_stint_min
             // 
             label_max_stint_min.AutoSize = true;
-            label_max_stint_min.Location = new Point(272, 58);
+            label_max_stint_min.Location = new Point(358, 80);
             label_max_stint_min.Name = "label_max_stint_min";
             label_max_stint_min.Size = new Size(28, 15);
             label_max_stint_min.TabIndex = 18;
@@ -366,7 +366,7 @@
             numericUpDown_pits.Size = new Size(74, 23);
             numericUpDown_pits.TabIndex = 11;
             numericUpDown_pits.TextAlign = HorizontalAlignment.Center;
-            numericUpDown_pits.KeyPress += numericUpDown_pits_KeyPress;
+            numericUpDown_pits.KeyPress += NumericUpDown_pits_KeyPress;
             // 
             // label_max_stint
             // 
@@ -374,9 +374,9 @@
             label_max_stint.BorderStyle = BorderStyle.FixedSingle;
             label_max_stint.Location = new Point(251, 29);
             label_max_stint.Name = "label_max_stint";
-            label_max_stint.Size = new Size(135, 20);
+            label_max_stint.Size = new Size(135, 38);
             label_max_stint.TabIndex = 19;
-            label_max_stint.Text = "Max stint duration";
+            label_max_stint.Text = "Maximum stint duration";
             label_max_stint.TextAlign = ContentAlignment.MiddleCenter;
             // 
             // label_pits_options
@@ -454,7 +454,7 @@
             comboBox_class.Size = new Size(72, 23);
             comboBox_class.TabIndex = 2;
             comboBox_class.Text = "CLASS";
-            comboBox_class.SelectedIndexChanged += comboBox_class_SelectedIndexChanged;
+            comboBox_class.SelectedIndexChanged += ComboBox_class_SelectedIndexChanged;
             // 
             // comboBox_track
             // 
@@ -464,7 +464,7 @@
             comboBox_track.Size = new Size(376, 23);
             comboBox_track.TabIndex = 5;
             comboBox_track.Text = "TRACK";
-            comboBox_track.SelectedIndexChanged += comboBox_track_SelectedIndexChanged;
+            comboBox_track.SelectedIndexChanged += ComboBox_track_SelectedIndexChanged;
             // 
             // label_choose_class
             // 
@@ -497,7 +497,7 @@
             comboBox_car.Size = new Size(294, 23);
             comboBox_car.TabIndex = 3;
             comboBox_car.Text = "CAR";
-            comboBox_car.SelectedIndexChanged += comboBox_car_SelectedIndexChanged;
+            comboBox_car.SelectedIndexChanged += ComboBox_car_SelectedIndexChanged;
             // 
             // button_calculate
             // 
@@ -509,7 +509,7 @@
             button_calculate.TabIndex = 10;
             button_calculate.Text = "Calculate";
             button_calculate.UseVisualStyleBackColor = false;
-            button_calculate.Click += button_calculate_Click;
+            button_calculate.Click += Button_calculate_Click;
             // 
             // panel_pit_stop_strategy
             // 
@@ -846,7 +846,7 @@
             // 
             resetDataToolStripMenuItem1.DropDownItems.AddRange(new ToolStripItem[] { resetAllDataToolStripMenuItem, resetCurrentCartrackToolStripMenuItem });
             resetDataToolStripMenuItem1.Name = "resetDataToolStripMenuItem1";
-            resetDataToolStripMenuItem1.Size = new Size(180, 22);
+            resetDataToolStripMenuItem1.Size = new Size(144, 22);
             resetDataToolStripMenuItem1.Text = "Reset data";
             // 
             // resetAllDataToolStripMenuItem
@@ -854,21 +854,21 @@
             resetAllDataToolStripMenuItem.Name = "resetAllDataToolStripMenuItem";
             resetAllDataToolStripMenuItem.Size = new Size(235, 22);
             resetAllDataToolStripMenuItem.Text = "Reset all data";
-            resetAllDataToolStripMenuItem.Click += resetAllDataToolStripMenuItem_Click;
+            resetAllDataToolStripMenuItem.Click += ResetAllDataToolStripMenuItem_Click;
             // 
             // resetCurrentCartrackToolStripMenuItem
             // 
             resetCurrentCartrackToolStripMenuItem.Name = "resetCurrentCartrackToolStripMenuItem";
             resetCurrentCartrackToolStripMenuItem.Size = new Size(235, 22);
             resetCurrentCartrackToolStripMenuItem.Text = "Reset current car/track";
-            resetCurrentCartrackToolStripMenuItem.Click += resetCurrentCartrackToolStripMenuItem_Click;
+            resetCurrentCartrackToolStripMenuItem.Click += ResetCurrentCartrackToolStripMenuItem_Click;
             // 
             // exitToolStripMenuItem
             // 
             exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            exitToolStripMenuItem.Size = new Size(180, 22);
+            exitToolStripMenuItem.Size = new Size(144, 22);
             exitToolStripMenuItem.Text = "Exit";
-            exitToolStripMenuItem.Click += exitToolStripMenuItem_Click;
+            exitToolStripMenuItem.Click += ExitToolStripMenuItem_Click;
             // 
             // ToolStripMenuItem_help
             // 
@@ -877,7 +877,7 @@
             ToolStripMenuItem_help.Name = "ToolStripMenuItem_help";
             ToolStripMenuItem_help.Size = new Size(47, 20);
             ToolStripMenuItem_help.Text = "Help";
-            ToolStripMenuItem_help.Click += helpToolStripMenuItem_Click;
+            ToolStripMenuItem_help.Click += HelpToolStripMenuItem_Click;
             // 
             // ToolStripMenuItem_github
             // 
@@ -886,7 +886,7 @@
             ToolStripMenuItem_github.Name = "ToolStripMenuItem_github";
             ToolStripMenuItem_github.Size = new Size(61, 20);
             ToolStripMenuItem_github.Text = "GitHub";
-            ToolStripMenuItem_github.Click += gitHubToolStripMenuItem_Click;
+            ToolStripMenuItem_github.Click += GitHubToolStripMenuItem_Click;
             // 
             // Form1
             // 

--- a/FCalcACC/Form1.Designer.cs
+++ b/FCalcACC/Form1.Designer.cs
@@ -91,7 +91,9 @@
             menuStrip1 = new MenuStrip();
             menuStrip2 = new MenuStrip();
             toolStripMenuItem_menu = new ToolStripMenuItem();
-            resetDataToolStripMenuItem = new ToolStripMenuItem();
+            resetDataToolStripMenuItem1 = new ToolStripMenuItem();
+            resetAllDataToolStripMenuItem = new ToolStripMenuItem();
+            resetCurrentCartrackToolStripMenuItem = new ToolStripMenuItem();
             exitToolStripMenuItem = new ToolStripMenuItem();
             ToolStripMenuItem_help = new ToolStripMenuItem();
             ToolStripMenuItem_github = new ToolStripMenuItem();
@@ -323,6 +325,7 @@
             comboBox_pit_options.Name = "comboBox_pit_options";
             comboBox_pit_options.Size = new Size(155, 23);
             comboBox_pit_options.TabIndex = 12;
+            comboBox_pit_options.SelectedIndexChanged += comboBox_pit_options_SelectedIndexChanged;
             // 
             // textBox_max_stint
             // 
@@ -833,23 +836,37 @@
             // toolStripMenuItem_menu
             // 
             toolStripMenuItem_menu.BackColor = Color.Gainsboro;
-            toolStripMenuItem_menu.DropDownItems.AddRange(new ToolStripItem[] { resetDataToolStripMenuItem, exitToolStripMenuItem });
+            toolStripMenuItem_menu.DropDownItems.AddRange(new ToolStripItem[] { resetDataToolStripMenuItem1, exitToolStripMenuItem });
             toolStripMenuItem_menu.Font = new Font("Consolas", 9.75F, FontStyle.Bold);
             toolStripMenuItem_menu.Name = "toolStripMenuItem_menu";
             toolStripMenuItem_menu.Size = new Size(47, 20);
             toolStripMenuItem_menu.Text = "Menu";
             // 
-            // resetDataToolStripMenuItem
+            // resetDataToolStripMenuItem1
             // 
-            resetDataToolStripMenuItem.Name = "resetDataToolStripMenuItem";
-            resetDataToolStripMenuItem.Size = new Size(144, 22);
-            resetDataToolStripMenuItem.Text = "Reset data";
-            resetDataToolStripMenuItem.Click += resetDataToolStripMenuItem_Click;
+            resetDataToolStripMenuItem1.DropDownItems.AddRange(new ToolStripItem[] { resetAllDataToolStripMenuItem, resetCurrentCartrackToolStripMenuItem });
+            resetDataToolStripMenuItem1.Name = "resetDataToolStripMenuItem1";
+            resetDataToolStripMenuItem1.Size = new Size(180, 22);
+            resetDataToolStripMenuItem1.Text = "Reset data";
+            // 
+            // resetAllDataToolStripMenuItem
+            // 
+            resetAllDataToolStripMenuItem.Name = "resetAllDataToolStripMenuItem";
+            resetAllDataToolStripMenuItem.Size = new Size(235, 22);
+            resetAllDataToolStripMenuItem.Text = "Reset all data";
+            resetAllDataToolStripMenuItem.Click += resetAllDataToolStripMenuItem_Click;
+            // 
+            // resetCurrentCartrackToolStripMenuItem
+            // 
+            resetCurrentCartrackToolStripMenuItem.Name = "resetCurrentCartrackToolStripMenuItem";
+            resetCurrentCartrackToolStripMenuItem.Size = new Size(235, 22);
+            resetCurrentCartrackToolStripMenuItem.Text = "Reset current car/track";
+            resetCurrentCartrackToolStripMenuItem.Click += resetCurrentCartrackToolStripMenuItem_Click;
             // 
             // exitToolStripMenuItem
             // 
             exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            exitToolStripMenuItem.Size = new Size(144, 22);
+            exitToolStripMenuItem.Size = new Size(180, 22);
             exitToolStripMenuItem.Text = "Exit";
             exitToolStripMenuItem.Click += exitToolStripMenuItem_Click;
             // 
@@ -979,6 +996,8 @@
         private Label label_max_stint;
         private CheckBox checkBox_max_stint;
         private ToolStripMenuItem ToolStripMenuItem_github;
-        private ToolStripMenuItem resetDataToolStripMenuItem;
+        private ToolStripMenuItem resetDataToolStripMenuItem1;
+        private ToolStripMenuItem resetAllDataToolStripMenuItem;
+        private ToolStripMenuItem resetCurrentCartrackToolStripMenuItem;
     }
 }

--- a/FCalcACC/Form1.cs
+++ b/FCalcACC/Form1.cs
@@ -9,23 +9,23 @@ namespace FCalcACC
     {
         public class Car
         {
-            public string car_name { get; set; }
-            public string class_name { get; set; }
+            public string CarName { get; set; }
+            public string ClassName { get; set; }
         }
 
         public class Track
         {
-            public string track_name { get; set; }
-            public string track_lap_time { get; set; }
-            public string track_pit_duration { get; set; }
-            public List<CarTrackFuel> car_track_fuel { get; set; }
+            public string TrackName { get; set; }
+            public string TrackLapTime { get; set; }
+            public string TrackPitDuration { get; set; }
+            public List<CarTrackFuel> CarTrackFuel { get; set; }
         }
 
         public class CarTrackFuel
         {
-            public string car_name { get; set; }
-            public string fuel_per_lap { get; set; }
-            public string tank_capacity { get; set; }
+            public string CarName { get; set; }
+            public string FuelPerLap { get; set; }
+            public string TankCapacity { get; set; }
         }
 
         public int GetTankCapacity(string carName, string trackName)
@@ -35,11 +35,11 @@ namespace FCalcACC
                 return 99999;
             }
 
-            var selected_track = all_tracks.FirstOrDefault(track => track.track_name.Equals(comboBox_track.Text));
-            var selected_trackCarFuel = selected_track.car_track_fuel.FirstOrDefault(
-                carTrackFuel => carTrackFuel.car_name.Equals(comboBox_car.Text));
+            var selected_track = all_tracks.FirstOrDefault(track => track.TrackName.Equals(comboBox_track.Text));
+            var selected_trackCarFuel = selected_track.CarTrackFuel.FirstOrDefault(
+                carTrackFuel => carTrackFuel.CarName.Equals(comboBox_car.Text));
 
-            return int.Parse(selected_trackCarFuel.tank_capacity);
+            return int.Parse(selected_trackCarFuel.TankCapacity);
         }
 
         public List<Track> all_tracks;
@@ -47,10 +47,10 @@ namespace FCalcACC
         public List<string> car_classes;
         public List<int> fuelPerStint;
         public List<int> lapsPerStint;
-        public List<NumericUpDown> dynamic_numericUpDowns = new List<NumericUpDown>();
-        public List<int> new_list_of_laps_to_pit = new List<int>();
-        public List<int> new_list_of_refuel = new List<int>();
-        public List<Label> dynamic_labels = new List<Label>();
+        public List<NumericUpDown> dynamic_numericUpDowns = [];
+        public List<int> new_list_of_laps_to_pit = [];
+        public List<int> new_list_of_refuel = [];
+        public List<Label> dynamic_labels = [];
 
         public double time_lost_in_pits;
         public int time_in_pits;
@@ -63,30 +63,30 @@ namespace FCalcACC
         public int number_of_pits;
         public double formation_lap_fuel;
         private double fuel_for_race;
-        private Debouncer recalculate_debouncer = new Debouncer(50);
-
-        bool is_strat_ok = true;
+        private Debouncer recalculate_debouncer = new(50);
+        private bool is_strat_ok = true;
         private bool is_recalculate_needed = true;
-        private string DECIMAL_SEPARATOR = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
-        private double ONE_L_PIT_TIME = 3.6;
-        private double ONE_L_MORE = 0.2;
-        public int DEFAULT_TIME_IN_PITS = 57;
 
-        public List<string> PIT_OPTIONS = new List<string>()
-        {
+        private readonly string DECIMAL_SEPARATOR = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+        private readonly double ONE_L_PIT_TIME = 3.6;
+        private readonly double ONE_L_MORE = 0.2;
+        public readonly int DEFAULT_TIME_IN_PITS = 57;
+
+        public List<string> PIT_OPTIONS =
+        [
             "Refuel only",
             "Fixed refuel only",
             "Tires only",
             "Refuel + tires",
             "1L refuel",
             "No pit stops"
-        };
+        ];
 
-        class Debouncer
+        private class Debouncer
         {
             // https://stackoverflow.com/a/47933557
 
-            private List<CancellationTokenSource> StepperCancelTokens = new List<CancellationTokenSource>();
+            private List<CancellationTokenSource> StepperCancelTokens = [];
             private int MillisecondsToWait;
             private readonly object _lockThis = new object(); // Use a locking object to prevent the debouncer
                                                               // to trigger again while the func is still running
@@ -137,21 +137,21 @@ namespace FCalcACC
             string tracks_resourse_name = "FCalcACC.car_track_data.TRACKS.json";
             Assembly assembly = Assembly.GetExecutingAssembly();
             using (Stream stream = assembly.GetManifestResourceStream(cars_resourse_name))
-            using (StreamReader reader = new StreamReader(stream))
+            using (StreamReader reader = new(stream))
             {
                 string cars_embedded = reader.ReadToEnd();
                 all_cars = JsonConvert.DeserializeObject<List<Car>>(cars_embedded);
+                int test = 0;
             }
 
             // Load Track objects, if no data file then load from embedded
             if (File.Exists("FCalcACC_data.json") == false)
             {
-                using (Stream stream = assembly.GetManifestResourceStream(tracks_resourse_name))
-                using (StreamReader reader = new StreamReader(stream))
-                {
-                    string tracks_embedded = reader.ReadToEnd();
-                    all_tracks = JsonConvert.DeserializeObject<List<Track>>(tracks_embedded);
-                }
+                using Stream stream = assembly.GetManifestResourceStream(tracks_resourse_name);
+                using StreamReader reader = new(stream);
+                string tracks_embedded = reader.ReadToEnd();
+                all_tracks = JsonConvert.DeserializeObject<List<Track>>(tracks_embedded);
+                int test = 0;
             }
             else
             {
@@ -182,6 +182,7 @@ namespace FCalcACC
                 }
             }
         }
+
         public void ResetSpecficCarTrack(ComboBox comboBoxCar, ComboBox comboBoxTrack)
         {
             if (comboBoxCar.Text == "CAR" || comboBoxTrack.Text == "TRACK")
@@ -195,28 +196,26 @@ namespace FCalcACC
 
             try
             {
-                using (Stream stream = assembly.GetManifestResourceStream(tracks_resourse_name))
-                using (StreamReader reader = new StreamReader(stream))
+                using Stream stream = assembly.GetManifestResourceStream(tracks_resourse_name);
+                using StreamReader reader = new(stream);
+                string tracks_embedded = reader.ReadToEnd();
+                List<Track> temp_tracks = JsonConvert.DeserializeObject<List<Track>>(tracks_embedded);
+
+                // Find the specific track in the list
+                Track default_track = temp_tracks.Find(t => t.TrackName == comboBoxTrack.Text);
+                CarTrackFuel default_car_track_fuel = default_track.CarTrackFuel.Find(
+                    c => c.CarName == comboBoxCar.Text);
+                foreach (var track in all_tracks)
                 {
-                    string tracks_embedded = reader.ReadToEnd();
-                    List<Track> temp_tracks = JsonConvert.DeserializeObject<List<Track>>(tracks_embedded);
-
-                    // Find the specific track in the list
-                    Track default_track = temp_tracks.Find(t => t.track_name == comboBoxTrack.Text);
-                    CarTrackFuel default_car_track_fuel = default_track.car_track_fuel.Find(
-                        c => c.car_name == comboBoxCar.Text);
-                    foreach (var track in all_tracks)
+                    if (track.TrackName.Equals(comboBox_track.Text))
                     {
-                        if (track.track_name.Equals(comboBox_track.Text))
-                        {
-                            track.track_lap_time = default_track.track_lap_time;
+                        track.TrackLapTime = default_track.TrackLapTime;
 
-                            foreach (var car_fuel in track.car_track_fuel)
+                        foreach (var car_fuel in track.CarTrackFuel)
+                        {
+                            if (car_fuel.CarName.Equals(comboBox_car.Text))
                             {
-                                if (car_fuel.car_name.Equals(comboBox_car.Text))
-                                {
-                                    car_fuel.fuel_per_lap = default_car_track_fuel.fuel_per_lap;
-                                }
+                                car_fuel.FuelPerLap = default_car_track_fuel.FuelPerLap;
                             }
                         }
                     }
@@ -245,7 +244,7 @@ namespace FCalcACC
 
         public void LoadCarClasses(ComboBox comboBoxClass)
         {
-            car_classes = all_cars.Select(car => car.class_name).Distinct().ToList();
+            car_classes = all_cars.Select(car => car.ClassName).Distinct().ToList();
 
             foreach (var car_class in car_classes)
             {
@@ -258,11 +257,11 @@ namespace FCalcACC
             comboBoxCar.ResetText();
             comboBoxCar.Items.Clear();
 
-            var cars_within_a_class = all_cars.Where(car => car.class_name.Contains(car_class));
+            var cars_within_a_class = all_cars.Where(car => car.ClassName.Contains(car_class));
 
             foreach (var car in cars_within_a_class)
             {
-                comboBoxCar.Items.Add(car.car_name);
+                comboBoxCar.Items.Add(car.CarName);
             }
             comboBoxCar.Text = "CAR";
 
@@ -276,11 +275,11 @@ namespace FCalcACC
         {
             foreach (var track in all_tracks)
             {
-                comboBoxTrack.Items.Add(track.track_name);
+                comboBoxTrack.Items.Add(track.TrackName);
             }
         }
 
-        public void LoadPitOptions(ComboBox comboBoxPit, List<string> pitOptions)
+        public static void LoadPitOptions(ComboBox comboBoxPit, List<string> pitOptions)
         {
             foreach (var pit_option in pitOptions)
             {
@@ -288,44 +287,44 @@ namespace FCalcACC
             }
         }
 
-        private void comboBox_class_SelectedIndexChanged(object sender, EventArgs e)
+        private void ComboBox_class_SelectedIndexChanged(object sender, EventArgs e)
         {
             // Load cars from selected class when comboBox_class changes
             LoadCars(comboBox_car, comboBox_class.Text);
         }
 
         // Restrictions to key presses in textBoxes, numericUpDowns
-        private void textBox_race_h_KeyPress(object sender, KeyPressEventArgs e)
+        private void TextBox_race_h_KeyPress(object sender, KeyPressEventArgs e)
         {
             e.Handled = !char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar);
         }
 
-        private void textBox_race_min_KeyPress(object sender, KeyPressEventArgs e)
+        private void TextBox_race_min_KeyPress(object sender, KeyPressEventArgs e)
         {
             e.Handled = !char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar);
         }
 
-        private void textBox_lap_time_min_KeyPress(object sender, KeyPressEventArgs e)
+        private void TextBox_lap_time_min_KeyPress(object sender, KeyPressEventArgs e)
         {
             e.Handled = !char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar);
         }
 
-        private void textBox_lap_time_sec_KeyPress(object sender, KeyPressEventArgs e)
+        private void TextBox_lap_time_sec_KeyPress(object sender, KeyPressEventArgs e)
         {
             e.Handled = !char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar) && e.KeyChar != '.' && e.KeyChar != ',';
         }
 
-        private void textBox_fuel_per_lap_KeyPress(object sender, KeyPressEventArgs e)
+        private void TextBox_fuel_per_lap_KeyPress(object sender, KeyPressEventArgs e)
         {
             e.Handled = !char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar) && e.KeyChar != '.' && e.KeyChar != ',';
         }
 
-        private void numericUpDown_pits_KeyPress(object sender, KeyPressEventArgs e)
+        private void NumericUpDown_pits_KeyPress(object sender, KeyPressEventArgs e)
         {
             e.Handled = !char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar);
         }
 
-        private void textBox_max_stint_KeyPress(object sender, KeyPressEventArgs e)
+        private void TextBox_max_stint_KeyPress(object sender, KeyPressEventArgs e)
         {
             e.Handled = !char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar);
         }
@@ -367,8 +366,8 @@ namespace FCalcACC
             {
                 // calculate time lost in pits when track IS selected
 
-                var selected_track_object = all_tracks.FirstOrDefault(track => track.track_name.Contains(selected_track));
-                int.TryParse(selected_track_object.track_pit_duration, out time_in_pits);
+                var selected_track_object = all_tracks.FirstOrDefault(track => track.TrackName.Contains(selected_track));
+                int.TryParse(selected_track_object.TrackPitDuration, out time_in_pits);
 
                 switch (comboBoxPitOptions.Text)
                 {
@@ -410,8 +409,8 @@ namespace FCalcACC
             if (selected_track != "TRACK")
             {
                 // when track IS selected
-                var selected_track_object = all_tracks.FirstOrDefault(track => track.track_name.Contains(selected_track));
-                int.TryParse(selected_track_object.track_pit_duration, out time_in_pits);
+                var selected_track_object = all_tracks.FirstOrDefault(track => track.TrackName.Contains(selected_track));
+                int.TryParse(selected_track_object.TrackPitDuration, out time_in_pits);
             }
             else
             {
@@ -452,7 +451,7 @@ namespace FCalcACC
                 textBoxRaceMin.Text = min_race.ToString();
             }
 
-            if (h_race > 24)
+            if (h_race > 24 || h_race == 24 && min_race != 0)
             {
                 // if someone iserts more than 24h then set 24 for hours and 0 for mins
                 h_race = 24;
@@ -603,7 +602,7 @@ namespace FCalcACC
 
         public void CalculatePitStops(Panel panelPitStopStrategy, Label labelFuelRaceResult, NumericUpDown numericUpDownPits,
             ComboBox comboBoxPitOptions, out string labelFuelStartResultText, out List<int> fuelPerStint,
-            out List<int> lapsPerStint, List<int> newListOfLapsToPit)
+            out List<int> lapsPerStint)
         {
             // calculate pit stop strategy based on number of pit stops, pit options, max stint duration, tank capacity etc.
 
@@ -614,37 +613,46 @@ namespace FCalcACC
             panelPitStopStrategy.Controls.Clear();
 
             // groupBox for the start of the race
-            GroupBox groupBox_start = new GroupBox();
-            groupBox_start.Text = "Stint 1 - Start of the race";
-            groupBox_start.BackColor = Color.Gainsboro;
-            groupBox_start.Font = groupBox_car_track.Font;
-            groupBox_start.Location = new Point(16, 26);
-            Size groupBox_size = new Size(385, 83);
-            groupBox_start.Size = groupBox_size;
+            Size groupBox_size = new(385, 83);
+            GroupBox groupBox_start = new()
+            {
+                Text = "Stint 1 - Start of the race",
+                BackColor = Color.Gainsboro,
+                Font = groupBox_car_track.Font,
+                Location = new Point(16, 26),
+                Size = groupBox_size
+            };
             panelPitStopStrategy.Controls.Add(groupBox_start);
 
             // tableLayout with results for groupBox above
-            TableLayoutPanel tableLayoutPanel_start = new TableLayoutPanel();
-            tableLayoutPanel_start.Size = new Size(350, 32);
-            tableLayoutPanel_start.CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset;
-            tableLayoutPanel_start.ColumnCount = 2;
+            TableLayoutPanel tableLayoutPanel_start = new()
+            {
+                Size = new Size(350, 32),
+                CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset,
+                ColumnCount = 2,
+                Location = new Point(15, 35)
+            };
             tableLayoutPanel_start.ColumnStyles.Clear();
             tableLayoutPanel_start.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
             tableLayoutPanel_start.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
             tableLayoutPanel_start.RowCount = 1;
-            tableLayoutPanel_start.Location = new Point(15, 35);
+
             groupBox_start.Controls.Add(tableLayoutPanel_start);
 
             // labels that are inside tableLayout above
-            Label label_fuel_for_start = new Label();
-            label_fuel_for_start.Text = "Fuel for the start";
-            label_fuel_for_start.Dock = DockStyle.Fill;
-            label_fuel_for_start.TextAlign = ContentAlignment.MiddleCenter;
-            label_fuel_for_start.Size = new Size(130, 17);
+            Label label_fuel_for_start = new()
+            {
+                Text = "Fuel for the start",
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleCenter,
+                Size = new Size(130, 17)
+            };
 
-            Label label_fuel_start_result = new Label();
-            label_fuel_start_result.Dock = DockStyle.Fill;
-            label_fuel_start_result.TextAlign = ContentAlignment.MiddleCenter;
+            Label label_fuel_start_result = new()
+            {
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleCenter
+            };
             this.Controls.Add(label_fuel_start_result);
             dynamic_labels.Add(label_fuel_start_result);
 
@@ -654,8 +662,8 @@ namespace FCalcACC
             number_of_pits = (int)numericUpDownPits.Value;
 
             // fuelPerStint, lapsPerStint, labelFuelStartResultText are for testing purposes
-            fuelPerStint = new List<int>();
-            lapsPerStint = new List<int>();
+            fuelPerStint = [];
+            lapsPerStint = [];
             labelFuelStartResultText = "";
 
             int tank_capacity;
@@ -682,7 +690,7 @@ namespace FCalcACC
                 {
                     number_of_pits = 1;
                     numericUpDownPits.Value = number_of_pits;
-                    button_calculate_Click(button_calculate, EventArgs.Empty);
+                    Button_calculate_Click(button_calculate, EventArgs.Empty);
                     return;
                 }
                 else if (comboBox_car.Text != "CAR" && comboBox_track.Text != "TRACK")
@@ -697,7 +705,7 @@ namespace FCalcACC
                     }
 
                     numericUpDownPits.Value = number_of_pits;
-                    button_calculate_Click(button_calculate, EventArgs.Empty);
+                    Button_calculate_Click(button_calculate, EventArgs.Empty);
                     return;
                 }
             }
@@ -710,7 +718,7 @@ namespace FCalcACC
                 number_of_pits = Math.Max(number_of_pits_tank, number_of_pits_stint);
 
                 numericUpDownPits.Value = number_of_pits;
-                button_calculate_Click(button_calculate, EventArgs.Empty);
+                Button_calculate_Click(button_calculate, EventArgs.Empty);
                 return;
             }
 
@@ -721,7 +729,7 @@ namespace FCalcACC
             {
                 number_of_pits = race_duration_secs / (int.Parse(textBox_max_stint.Text) * 60);
                 numericUpDownPits.Value = number_of_pits;
-                button_calculate_Click(button_calculate, EventArgs.Empty);
+                Button_calculate_Click(button_calculate, EventArgs.Empty);
                 return;
             }
 
@@ -737,23 +745,27 @@ namespace FCalcACC
                 // warning if tank capacity is lower than fuel require for the race
                 if (fuel_for_race_round_up > tank_capacity)
                 {
-                    GroupBox groupBox_warning = new GroupBox();
-                    groupBox_warning.Location = new Point(16, 124);
-                    groupBox_warning.Size = new Size(385, 130);
-                    groupBox_warning.Font = groupBox_car_track.Font;
-                    groupBox_warning.ForeColor = Color.Red;
-                    groupBox_warning.BackColor = groupBox_start.BackColor;
-                    groupBox_warning.Text = "WARNING";
+                    GroupBox groupBox_warning = new()
+                    {
+                        Location = new Point(16, 124),
+                        Size = new Size(385, 130),
+                        Font = groupBox_car_track.Font,
+                        ForeColor = Color.Red,
+                        BackColor = groupBox_start.BackColor,
+                        Text = "WARNING"
+                    };
                     panelPitStopStrategy.Controls.Add(groupBox_warning);
 
-                    Label label_warning = new Label();
-                    label_warning.Text = "Fuel needed for this race (" + fuel_for_race_round_up.ToString() +
-                        " L) is greater than tank capacity (" + tank_capacity.ToString() + " L). " +
+                    Label label_warning = new()
+                    {
+                        Text = "Fuel needed for this race (" + fuel_for_race_round_up.ToString() +
+                        " L) is greater than fuel tank capacity (" + tank_capacity.ToString() + " L). " +
                         "\n\nConsider adding a pit stop with refuel or " +
-                        "fuel saving (" + (fuel_for_race_round_up - tank_capacity).ToString() + " L) during the race.";
-                    label_warning.Location = new Point(16, 30);
-                    label_warning.Size = new Size(350, 90);
-                    label_warning.ForeColor = Color.Black;
+                        "fuel saving (" + (fuel_for_race_round_up - tank_capacity).ToString() + " L) during the race.",
+                        Location = new Point(16, 30),
+                        Size = new Size(350, 90),
+                        ForeColor = Color.Black
+                    };
                     groupBox_warning.Controls.Add(label_warning);
                 }
             }
@@ -792,7 +804,7 @@ namespace FCalcACC
                 }
 
                 // variables that will be used when when 1L strategy isnt optimal
-                List<int> fuel_1L_adjusted = new List<int>();
+                List<int> fuel_1L_adjusted = [];
                 int full_tank_count = fuel_for_race_round_up / tank_capacity;
                 int full_tank_sum = 0;
 
@@ -842,34 +854,42 @@ namespace FCalcACC
 
                         label_fuel_start_result.Text = label_fuel_race_result.Text;
 
-                        GroupBox groupBox_temp = new GroupBox();
-                        groupBox_temp.Name = name_for_groupbox;
-                        groupBox_temp.Location = new Point(16, y_groupBox);
-                        groupBox_temp.Font = groupBox_car_track.Font;
-                        groupBox_temp.Size = groupBox_size;
-                        groupBox_temp.BackColor = groupBox_start.BackColor;
-                        groupBox_temp.Text = "Stint " + stint;
+                        GroupBox groupBox_temp = new()
+                        {
+                            Name = name_for_groupbox,
+                            Location = new Point(16, y_groupBox),
+                            Font = groupBox_car_track.Font,
+                            Size = groupBox_size,
+                            BackColor = groupBox_start.BackColor,
+                            Text = "Stint " + stint
+                        };
                         panelPitStopStrategy.Controls.Add(groupBox_temp);
 
-                        TableLayoutPanel table_temp = new TableLayoutPanel();
-                        table_temp.Name = name_for_table;
-                        table_temp.Location = new Point(16, 30);
-                        table_temp.CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset;
+                        TableLayoutPanel table_temp = new()
+                        {
+                            Name = name_for_table,
+                            Location = new Point(16, 30),
+                            CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset
+                        };
                         table_temp.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
                         table_temp.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
 
-                        NumericUpDown numericUpDown_laps_temp = new NumericUpDown();
-                        numericUpDown_laps_temp.Name = "numericUpDown_laps_stint" + stint.ToString();
-                        numericUpDown_laps_temp.Dock = DockStyle.Fill;
-                        numericUpDown_laps_temp.TextAlign = HorizontalAlignment.Center;
-                        numericUpDown_laps_temp.Maximum = 999;
+                        NumericUpDown numericUpDown_laps_temp = new()
+                        {
+                            Name = "numericUpDown_laps_stint" + stint.ToString(),
+                            Dock = DockStyle.Fill,
+                            TextAlign = HorizontalAlignment.Center,
+                            Maximum = 999
+                        };
                         this.Controls.Add(numericUpDown_laps_temp);
                         dynamic_numericUpDowns.Add(numericUpDown_laps_temp);
 
-                        Label label_refuel_temp = new Label();
-                        label_refuel_temp.Dock = DockStyle.Fill;
-                        label_refuel_temp.TextAlign = ContentAlignment.MiddleCenter;
-                        label_refuel_temp.Name = name_for_refuel_label;
+                        Label label_refuel_temp = new()
+                        {
+                            Dock = DockStyle.Fill,
+                            TextAlign = ContentAlignment.MiddleCenter,
+                            Name = name_for_refuel_label
+                        };
 
                         double current_part = Math.Min(number_of_laps_remaining, laps_per_stint);
                         current_laps += current_part;
@@ -893,23 +913,27 @@ namespace FCalcACC
                         // show a warning if fuel tank capacity is lower than fuel for the whole race
                         if (fuel_for_race_round_up > tank_capacity && i == 1)
                         {
-                            GroupBox groupBox_warning = new GroupBox();
-                            groupBox_warning.Location = new Point(16, y_groupBox);
-                            groupBox_warning.Size = new Size(385, 130);
-                            groupBox_warning.Font = groupBox_car_track.Font;
-                            groupBox_warning.ForeColor = Color.Red;
-                            groupBox_warning.BackColor = groupBox_start.BackColor;
-                            groupBox_warning.Text = "WARNING";
+                            GroupBox groupBox_warning = new()
+                            {
+                                Location = new Point(16, y_groupBox),
+                                Size = new Size(385, 130),
+                                Font = groupBox_car_track.Font,
+                                ForeColor = Color.Red,
+                                BackColor = groupBox_start.BackColor,
+                                Text = "WARNING"
+                            };
                             panelPitStopStrategy.Controls.Add(groupBox_warning);
 
-                            Label label_warning = new Label();
-                            label_warning.Text = "Fuel needed for this race (" + fuel_for_race_round_up.ToString() +
-                                " L) is greater than tank capacity (" + tank_capacity.ToString() + " L). " +
+                            Label label_warning = new()
+                            {
+                                Text = "Fuel needed for this race (" + fuel_for_race_round_up.ToString() +
+                                " L) is greater than fuel tank capacity (" + tank_capacity.ToString() + " L). " +
                                 "\n\nConsider changing a pit stop option with refuel or " +
-                                "fuel saving (" + (fuel_for_race_round_up - tank_capacity).ToString() + " L) during the race.";
-                            label_warning.Location = new Point(16, 30);
-                            label_warning.Size = new Size(350, 90);
-                            label_warning.ForeColor = Color.Black;
+                                "fuel saving (" + (fuel_for_race_round_up - tank_capacity).ToString() + " L) during the race.",
+                                Location = new Point(16, 30),
+                                Size = new Size(350, 90),
+                                ForeColor = Color.Black
+                            };
                             groupBox_warning.Controls.Add(label_warning);
                         }
                     }
@@ -923,11 +947,13 @@ namespace FCalcACC
                         if (fuel_for_race_round_up > (tank_capacity + number_of_pits))
                         {
                             groupBox_start.Size = new Size(385, 123);
-                            Label label_tank = new Label();
-                            label_tank.Text = "Exceeded fuel tank capacity of " + tank_capacity.ToString() + 
-                                " L for 1L strategy. Adjusted with higher refuel.";
-                            label_tank.Size = new Size(350, 50);
-                            label_tank.Location = new Point(16, 74);
+                            Label label_tank = new()
+                            {
+                                Text = "Exceeded fuel tank capacity of " + tank_capacity.ToString() +
+                                " L for 1L strategy. Adjusted with higher refuel.",
+                                Size = new Size(350, 50),
+                                Location = new Point(16, 74)
+                            };
                             groupBox_start.Controls.Add(label_tank);
 
                             if (i == number_of_pits)
@@ -946,34 +972,43 @@ namespace FCalcACC
 
                                 label_fuel_start_result.Text = (fuel_for_race_round_up - number_of_pits).ToString() + " L";
 
-                                GroupBox groupBox_temp = new GroupBox();
-                                groupBox_temp.Name = name_for_groupbox;
-                                groupBox_temp.Location = new Point(16, y_groupBox);
-                                groupBox_temp.Size = new Size(385, 103);
-                                groupBox_temp.Font = groupBox_car_track.Font;
-                                groupBox_temp.BackColor = groupBox_start.BackColor;
-                                groupBox_temp.Text = "Stint " + stint;
+                                GroupBox groupBox_temp = new()
+                                {
+                                    Name = name_for_groupbox,
+                                    Location = new Point(16, y_groupBox),
+                                    Size = new Size(385, 103),
+                                    Font = groupBox_car_track.Font,
+                                    BackColor = groupBox_start.BackColor,
+                                    Text = "Stint " + stint
+                                };
                                 panelPitStopStrategy.Controls.Add(groupBox_temp);
 
-                                TableLayoutPanel table_temp = new TableLayoutPanel();
-                                table_temp.Name = name_for_table;
-                                table_temp.Location = new Point(16, 30);
+                                TableLayoutPanel table_temp = new()
+                                {
+                                    Name = name_for_table,
+                                    Location = new Point(16, 30),
+                                    CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset
+                                };
                                 table_temp.ColumnStyles.Clear();
                                 table_temp.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
                                 table_temp.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
-                                table_temp.CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset;
 
-                                Label label_refuel_temp = new Label();
-                                label_refuel_temp.Name = name_for_refuel_label;
-                                label_refuel_temp.Dock = DockStyle.Fill;
-                                label_refuel_temp.TextAlign = ContentAlignment.MiddleCenter;
-                                label_refuel_temp.Text = "Refuel for Stint " + stint.ToString();
 
-                                NumericUpDown numericUpDown_laps_temp = new NumericUpDown();
-                                numericUpDown_laps_temp.Name = "numericUpDown_laps_stint" + stint.ToString();
-                                numericUpDown_laps_temp.Dock = DockStyle.Fill;
-                                numericUpDown_laps_temp.TextAlign = HorizontalAlignment.Center;
-                                numericUpDown_laps_temp.Maximum = 999;
+                                Label label_refuel_temp = new()
+                                {
+                                    Name = name_for_refuel_label,
+                                    Dock = DockStyle.Fill,
+                                    TextAlign = ContentAlignment.MiddleCenter,
+                                    Text = "Refuel for Stint " + stint.ToString()
+                                };
+
+                                NumericUpDown numericUpDown_laps_temp = new()
+                                {
+                                    Name = "numericUpDown_laps_stint" + stint.ToString(),
+                                    Dock = DockStyle.Fill,
+                                    TextAlign = HorizontalAlignment.Center,
+                                    Maximum = 999
+                                };
                                 this.Controls.Add(numericUpDown_laps_temp);
                                 dynamic_numericUpDowns.Add(numericUpDown_laps_temp);
 
@@ -984,17 +1019,22 @@ namespace FCalcACC
                                 number_of_laps_remaining -= laps_per_stint;
                                 lapsPerStint.Add((int)Math.Ceiling(current_laps));
 
-                                Label label_refuel_result_temp = new Label() { Text = "1 L" };
-                                label_refuel_result_temp.Name = name_for_refuel_result_label;
-                                label_refuel_result_temp.Dock = DockStyle.Fill;
-                                label_refuel_result_temp.TextAlign = ContentAlignment.MiddleCenter;
+                                Label label_refuel_result_temp = new()
+                                {
+                                    Text = "1 L",
+                                    Name = name_for_refuel_result_label,
+                                    Dock = DockStyle.Fill,
+                                    TextAlign = ContentAlignment.MiddleCenter
+                                };
                                 fuelPerStint.Add(1);
 
-                                Label label_laps_temp = new Label();
-                                label_laps_temp.Name = "label_laps_stint" + stint.ToString();
-                                label_laps_temp.Dock = DockStyle.Fill;
-                                label_laps_temp.TextAlign = ContentAlignment.MiddleCenter;
-                                label_laps_temp.Text = "Pit after lap";
+                                Label label_laps_temp = new()
+                                {
+                                    Name = "label_laps_stint" + stint.ToString(),
+                                    Dock = DockStyle.Fill,
+                                    TextAlign = ContentAlignment.MiddleCenter,
+                                    Text = "Pit after lap"
+                                };
 
                                 table_temp.Controls.Add(label_refuel_temp, 0, 1);
                                 table_temp.Controls.Add(label_refuel_result_temp, 1, 1);
@@ -1016,34 +1056,43 @@ namespace FCalcACC
 
                                 label_fuel_start_result.Text = tank_capacity.ToString() + " L";
 
-                                GroupBox groupBox_temp2 = new GroupBox();
-                                groupBox_temp2.Name = name_for_groupbox;
-                                groupBox_temp2.Location = new Point(16, y_groupBox);
-                                groupBox_temp2.Size = new Size(385, 103);
-                                groupBox_temp2.Font = groupBox_car_track.Font;
-                                groupBox_temp2.BackColor = groupBox_start.BackColor;
-                                groupBox_temp2.Text = "Stint " + stint;
+                                GroupBox groupBox_temp2 = new()
+                                {
+                                    Name = name_for_groupbox,
+                                    Location = new Point(16, y_groupBox),
+                                    Size = new Size(385, 103),
+                                    Font = groupBox_car_track.Font,
+                                    BackColor = groupBox_start.BackColor,
+                                    Text = "Stint " + stint
+                                };
                                 panelPitStopStrategy.Controls.Add(groupBox_temp2);
 
-                                TableLayoutPanel table_temp2 = new TableLayoutPanel();
-                                table_temp2.Name = name_for_table;
-                                table_temp2.Location = new Point(16, 30);
+                                TableLayoutPanel table_temp2 = new()
+                                {
+                                    Name = name_for_table,
+                                    Location = new Point(16, 30),
+                                    CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset
+                                };
                                 table_temp2.ColumnStyles.Clear();
                                 table_temp2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
                                 table_temp2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
-                                table_temp2.CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset;
 
-                                Label label_laps_temp2 = new Label();
-                                label_laps_temp2.Name = name_for_refuel_label;
-                                label_laps_temp2.Dock = DockStyle.Fill;
-                                label_laps_temp2.TextAlign = ContentAlignment.MiddleCenter;
-                                label_laps_temp2.Text = "Pit after lap";
 
-                                Label label_refuel_temp2 = new Label();
-                                label_refuel_temp2.Name = name_for_refuel_label;
-                                label_refuel_temp2.Dock = DockStyle.Fill;
-                                label_refuel_temp2.TextAlign = ContentAlignment.MiddleCenter;
-                                label_refuel_temp2.Text = "Refuel for Stint " + stint.ToString();
+                                Label label_laps_temp2 = new()
+                                {
+                                    Name = name_for_refuel_label,
+                                    Dock = DockStyle.Fill,
+                                    TextAlign = ContentAlignment.MiddleCenter,
+                                    Text = "Pit after lap"
+                                };
+
+                                Label label_refuel_temp2 = new()
+                                {
+                                    Name = name_for_refuel_label,
+                                    Dock = DockStyle.Fill,
+                                    TextAlign = ContentAlignment.MiddleCenter,
+                                    Text = "Refuel for Stint " + stint.ToString()
+                                };
 
                                 if (stint == 2)
                                 {
@@ -1060,11 +1109,13 @@ namespace FCalcACC
                                     more_time_in_pits += (fuel_for_this_stint - 1) * ONE_L_MORE;
                                 }
 
-                                NumericUpDown numericUpDown_laps_temp2 = new NumericUpDown();
-                                numericUpDown_laps_temp2.Name = "numericUpDown_laps_stint" + stint.ToString();
-                                numericUpDown_laps_temp2.Dock = DockStyle.Fill;
-                                numericUpDown_laps_temp2.TextAlign = HorizontalAlignment.Center;
-                                numericUpDown_laps_temp2.Maximum = 9999;
+                                NumericUpDown numericUpDown_laps_temp2 = new()
+                                {
+                                    Name = "numericUpDown_laps_stint" + stint.ToString(),
+                                    Dock = DockStyle.Fill,
+                                    TextAlign = HorizontalAlignment.Center,
+                                    Maximum = 9999
+                                };
                                 this.Controls.Add(numericUpDown_laps_temp2);
                                 dynamic_numericUpDowns.Add(numericUpDown_laps_temp2);
 
@@ -1088,11 +1139,13 @@ namespace FCalcACC
                                     numericUpDown_laps_temp2.Enabled = false;
                                 }
 
-                                Label label_refuel_result_temp2 = new Label();
-                                label_refuel_result_temp2.Name = name_for_refuel_result_label;
-                                label_refuel_result_temp2.Text = fuel_for_this_stint.ToString() + " L";
-                                label_refuel_result_temp2.Dock = DockStyle.Fill;
-                                label_refuel_result_temp2.TextAlign = ContentAlignment.MiddleCenter;
+                                Label label_refuel_result_temp2 = new()
+                                {
+                                    Name = name_for_refuel_result_label,
+                                    Text = fuel_for_this_stint.ToString() + " L",
+                                    Dock = DockStyle.Fill,
+                                    TextAlign = ContentAlignment.MiddleCenter
+                                };
 
                                 table_temp2.Controls.Add(label_refuel_temp2, 0, 1);
                                 table_temp2.Controls.Add(label_refuel_result_temp2, 1, 1);
@@ -1117,7 +1170,7 @@ namespace FCalcACC
                                     is_recalculate_needed = false;    // change to false so it wont be endless loop
                                     CalculatePitStops(panel_pit_stop_strategy, label_fuel_race_result, numericUpDown_pits, comboBox_pit_options,
                                         out string labelFuelStartResultTextForTesting, out List<int> fuelPerStintForTesting,
-                                        out List<int> lapsPitStintForTesting, new_list_of_laps_to_pit);
+                                        out List<int> lapsPitStintForTesting);
                                     is_recalculate_needed = true;     // change back to true for next calculations
                                     SaveData();
                                 }
@@ -1128,25 +1181,29 @@ namespace FCalcACC
                         // for the whole race
                         if (i == 1 && pit_stops_left < 0)
                         {
-                            GroupBox groupBox_warning = new GroupBox();
-                            groupBox_warning.Name = name_for_groupbox + "_warning";
-                            groupBox_warning.Location = new Point(16, y_groupBox);
-                            groupBox_warning.Size = new Size(385, 135);
-                            groupBox_warning.Font = groupBox_car_track.Font;
-                            groupBox_warning.ForeColor = Color.Red;
-                            groupBox_warning.BackColor = groupBox_start.BackColor;
-                            groupBox_warning.Text = "WARNING";
+                            GroupBox groupBox_warning = new()
+                            {
+                                Name = name_for_groupbox + "_warning",
+                                Location = new Point(16, y_groupBox),
+                                Size = new Size(385, 135),
+                                Font = groupBox_car_track.Font,
+                                ForeColor = Color.Red,
+                                BackColor = groupBox_start.BackColor,
+                                Text = "WARNING"
+                            };
                             panelPitStopStrategy.Controls.Add(groupBox_warning);
 
-                            Label label_warning = new Label();
-                            label_warning.Name = name_for_refuel_result_label + "_warning";
-                            label_warning.Text = "Fuel needed for this race (" + fuel_for_race_round_up.ToString() +
+                            Label label_warning = new()
+                            {
+                                Name = name_for_refuel_result_label + "_warning",
+                                Text = "Fuel needed for this race (" + fuel_for_race_round_up.ToString() +
                                 " L) is greater than sum of full tank pit stops (" + full_tank_sum.ToString() + " L). " +
                                 "\n\nConsider changing pit option to refuel and increase number of pit stops or " +
-                                "fuel saving (" + (fuel_for_race_round_up - full_tank_sum).ToString() + " L) during the race.";
-                            label_warning.Location = new Point(16, 30);
-                            label_warning.Size = new Size(350, 90);
-                            label_warning.ForeColor = Color.Black;
+                                "fuel saving (" + (fuel_for_race_round_up - full_tank_sum).ToString() + " L) during the race.",
+                                Location = new Point(16, 30),
+                                Size = new Size(350, 90),
+                                ForeColor = Color.Black
+                            };
                             groupBox_warning.Controls.Add(label_warning);
                         }
                     }
@@ -1158,36 +1215,45 @@ namespace FCalcACC
 
                         label_fuel_start_result.Text = fuel_first_stint.ToString() + " L";
 
-                        GroupBox groupBox_temp = new GroupBox();
-                        groupBox_temp.Name = name_for_groupbox;
-                        groupBox_temp.Location = new Point(16, y_groupBox);
-                        groupBox_temp.Size = new Size(385, 103);
-                        groupBox_temp.Font = groupBox_car_track.Font;
-                        groupBox_temp.BackColor = groupBox_start.BackColor;
-                        groupBox_temp.Text = "Stint " + stint;
+                        GroupBox groupBox_temp = new()
+                        {
+                            Name = name_for_groupbox,
+                            Location = new Point(16, y_groupBox),
+                            Size = new Size(385, 103),
+                            Font = groupBox_car_track.Font,
+                            BackColor = groupBox_start.BackColor,
+                            Text = "Stint " + stint
+                        };
                         panelPitStopStrategy.Controls.Add(groupBox_temp);
 
-                        TableLayoutPanel table_temp = new TableLayoutPanel();
-                        table_temp.Name = name_for_table;
-                        table_temp.Location = new Point(16, 30);
+                        TableLayoutPanel table_temp = new()
+                        {
+                            Name = name_for_table,
+                            Location = new Point(16, 30),
+                            CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset
+                        };
                         table_temp.ColumnStyles.Clear();
                         table_temp.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
                         table_temp.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
-                        table_temp.CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset;
 
-                        NumericUpDown numericUpDown_laps_temp = new NumericUpDown();
-                        numericUpDown_laps_temp.Name = "numericUpDown_laps_stint" + stint.ToString();
-                        numericUpDown_laps_temp.Dock = DockStyle.Fill;
-                        numericUpDown_laps_temp.TextAlign = HorizontalAlignment.Center;
-                        numericUpDown_laps_temp.Maximum = 99999;
+
+                        NumericUpDown numericUpDown_laps_temp = new()
+                        {
+                            Name = "numericUpDown_laps_stint" + stint.ToString(),
+                            Dock = DockStyle.Fill,
+                            TextAlign = HorizontalAlignment.Center,
+                            Maximum = 99999
+                        };
                         this.Controls.Add(numericUpDown_laps_temp);
                         dynamic_numericUpDowns.Add(numericUpDown_laps_temp);
 
-                        Label label_refuel_temp = new Label();
-                        label_refuel_temp.Name = name_for_refuel_label;
-                        label_refuel_temp.Dock = DockStyle.Fill;
-                        label_refuel_temp.TextAlign = ContentAlignment.MiddleCenter;
-                        label_refuel_temp.Text = "Refuel for Stint " + stint.ToString();
+                        Label label_refuel_temp = new()
+                        {
+                            Name = name_for_refuel_label,
+                            Dock = DockStyle.Fill,
+                            TextAlign = ContentAlignment.MiddleCenter,
+                            Text = "Refuel for Stint " + stint.ToString()
+                        };
 
                         double current_part_laps = Math.Min(number_of_laps_remaining, laps_per_stint);
                         current_laps += current_part_laps;
@@ -1205,17 +1271,21 @@ namespace FCalcACC
                         stints_left--;
                         fuelPerStint.Add(fuel_for_this_stint);
 
-                        Label label_laps_temp = new Label();
-                        label_laps_temp.Name = "label_laps_stint" + stint.ToString();
-                        label_laps_temp.Dock = DockStyle.Fill;
-                        label_laps_temp.TextAlign = ContentAlignment.MiddleCenter;
-                        label_laps_temp.Text = "Pit after lap";
+                        Label label_laps_temp = new()
+                        {
+                            Name = "label_laps_stint" + stint.ToString(),
+                            Dock = DockStyle.Fill,
+                            TextAlign = ContentAlignment.MiddleCenter,
+                            Text = "Pit after lap"
+                        };
 
-                        Label label_refuel_result_temp = new Label();
-                        label_refuel_result_temp.Name = name_for_refuel_result_label;
-                        label_refuel_result_temp.Text = fuel_for_this_stint.ToString() + " L";
-                        label_refuel_result_temp.Dock = DockStyle.Fill;
-                        label_refuel_result_temp.TextAlign = ContentAlignment.MiddleCenter;
+                        Label label_refuel_result_temp = new()
+                        {
+                            Name = name_for_refuel_result_label,
+                            Text = fuel_for_this_stint.ToString() + " L",
+                            Dock = DockStyle.Fill,
+                            TextAlign = ContentAlignment.MiddleCenter
+                        };
                         this.Controls.Add(label_refuel_result_temp);
                         dynamic_labels.Add(label_refuel_result_temp);
 
@@ -1233,25 +1303,29 @@ namespace FCalcACC
                         // for the whole race
                         if (i == 1 && pit_stops_left < 0 && full_tank_sum < fuel_for_race_round_up)
                         {
-                            GroupBox groupBox_warning = new GroupBox();
-                            groupBox_warning.Name = name_for_groupbox + "_warning";
-                            groupBox_warning.Location = new Point(16, y_groupBox);
-                            groupBox_warning.Size = new Size(385, 135);
-                            groupBox_warning.Font = groupBox_car_track.Font;
-                            groupBox_warning.ForeColor = Color.Red;
-                            groupBox_warning.BackColor = groupBox_start.BackColor;
-                            groupBox_warning.Text = "WARNING";
+                            GroupBox groupBox_warning = new()
+                            {
+                                Name = name_for_groupbox + "_warning",
+                                Location = new Point(16, y_groupBox),
+                                Size = new Size(385, 135),
+                                Font = groupBox_car_track.Font,
+                                ForeColor = Color.Red,
+                                BackColor = groupBox_start.BackColor,
+                                Text = "WARNING"
+                            };
                             panelPitStopStrategy.Controls.Add(groupBox_warning);
 
-                            Label label_warning = new Label();
-                            label_warning.Name = name_for_refuel_result_label + "_warning";
-                            label_warning.Text = "Fuel needed for this race (" + fuel_for_race_round_up.ToString() +
+                            Label label_warning = new()
+                            {
+                                Name = name_for_refuel_result_label + "_warning",
+                                Text = "Fuel needed for this race (" + fuel_for_race_round_up.ToString() +
                                 " L) is greater than sum of full tank pit stops (" + full_tank_sum.ToString() + " L). " +
                                 "\n\nConsider increasing number of pit stops or " +
-                                "fuel saving (" + (fuel_for_race_round_up - full_tank_sum).ToString() + " L) during the race.";
-                            label_warning.Location = new Point(16, 30);
-                            label_warning.Size = new Size(350, 90);
-                            label_warning.ForeColor = Color.Black;
+                                "fuel saving (" + (fuel_for_race_round_up - full_tank_sum).ToString() + " L) during the race.",
+                                Location = new Point(16, 30),
+                                Size = new Size(350, 90),
+                                ForeColor = Color.Black
+                            };
                             groupBox_warning.Controls.Add(label_warning);
                         }
                     }
@@ -1334,7 +1408,7 @@ namespace FCalcACC
 
             int max_stint_limit = 99999;    // big number so it wont be a limit if there is no maximum stint timer
             int tank_capacity = 99999;      // big number so it wont be a limit if there is no car and track selected
-            List<int> tank_capacity_limit = new List<int>();
+            List<int> tank_capacity_limit = [];
 
             if (comboBox_car.Text != "CAR" && comboBox_track.Text != "TRACK")
             {
@@ -1463,9 +1537,9 @@ namespace FCalcACC
             {
                 string selected_car = comboBox_car.Text;
                 string selected_track = comboBox_track.Text;
-                var track = all_tracks.Where(track => track.track_name.Equals(selected_track)).First();
+                var track = all_tracks.Where(track => track.TrackName.Equals(selected_track)).First();
 
-                float.TryParse(track.track_lap_time.Replace(".", DECIMAL_SEPARATOR).Replace(",", DECIMAL_SEPARATOR),
+                float.TryParse(track.TrackLapTime.Replace(".", DECIMAL_SEPARATOR).Replace(",", DECIMAL_SEPARATOR),
                     out float lap_time);
                 int lap_time_mins = (int)(lap_time / 60);
                 float lap_time_secs = lap_time % 60;
@@ -1474,8 +1548,8 @@ namespace FCalcACC
 
                 if (comboBox_car.Text != "CAR")
                 {
-                    CarTrackFuel car_fuel = track.car_track_fuel.Find(car => car.car_name == selected_car);
-                    textBox_fuel_per_lap.Text = car_fuel.fuel_per_lap;
+                    CarTrackFuel car_fuel = track.CarTrackFuel.Find(car => car.CarName == selected_car);
+                    textBox_fuel_per_lap.Text = car_fuel.FuelPerLap;
                 }
             }
         }
@@ -1486,15 +1560,15 @@ namespace FCalcACC
 
             foreach (var track in all_tracks)
             {
-                if (track.track_name.Equals(comboBox_track.Text))
+                if (track.TrackName.Equals(comboBox_track.Text))
                 {
-                    track.track_lap_time = lap_time_secs.ToString();
+                    track.TrackLapTime = lap_time_secs.ToString();
 
-                    foreach (var car_fuel in track.car_track_fuel)
+                    foreach (var car_fuel in track.CarTrackFuel)
                     {
-                        if (car_fuel.car_name.Equals(comboBox_car.Text))
+                        if (car_fuel.CarName.Equals(comboBox_car.Text))
                         {
-                            car_fuel.fuel_per_lap = textBox_fuel_per_lap.Text;
+                            car_fuel.FuelPerLap = textBox_fuel_per_lap.Text;
                         }
                     }
                 }
@@ -1522,16 +1596,18 @@ namespace FCalcACC
             listBox_formation.SelectedIndex = 0;
         }
 
-        public void ChangeTextBoxColor(TextBox textBox)
+        public static void ChangeTextBoxColor(TextBox textBox)
         {
-            // textBox will flash red color
+            // textBox will flash red color (for button_calculate_Click action)
 
             Color original_color = textBox.BackColor;
 
             textBox.BackColor = Color.Red;
 
-            System.Windows.Forms.Timer timer = new System.Windows.Forms.Timer();
-            timer.Interval = 1000;
+            System.Windows.Forms.Timer timer = new()
+            {
+                Interval = 1000
+            };
             timer.Tick += (sender, e) =>
             {
                 textBox.BackColor = original_color;
@@ -1543,9 +1619,9 @@ namespace FCalcACC
 
         private bool OnlyZeros(string text)
         {
-            // check if string consists only characters from the list below
+            // check if string consists only characters from the list below (for button_calculate_Click action)
 
-            List<char> chars = new List<char> { '0', '.', ',' };
+            List<char> chars = ['0', '.', ','];
 
             foreach (char c in text)
             {
@@ -1557,7 +1633,7 @@ namespace FCalcACC
             return false;
         }
 
-        private void button_calculate_Click(object sender, EventArgs e)
+        private void Button_calculate_Click(object sender, EventArgs e)
         {
             // if either lap time, fuel per lap or race duration is set to 0
             // prevent further calculations and flash textBox(es) with red color
@@ -1622,18 +1698,18 @@ namespace FCalcACC
             }
             CalculatePitStops(panel_pit_stop_strategy, label_fuel_race_result, numericUpDown_pits, comboBox_pit_options,
                 out string labelFuelStartResultTextForTesting, out List<int> fuelPerStint,
-                out List<int> lapsPerStint, new_list_of_laps_to_pit);
+                out List<int> lapsPerStint);
             SaveData();
         }
 
-        private void comboBox_car_SelectedIndexChanged(object sender, EventArgs e)
+        private void ComboBox_car_SelectedIndexChanged(object sender, EventArgs e)
         {
             // load new data when selected car changes
 
             LoadData();
         }
 
-        private void comboBox_track_SelectedIndexChanged(object sender, EventArgs e)
+        private void ComboBox_track_SelectedIndexChanged(object sender, EventArgs e)
         {
             // load new data when selected track changes
 
@@ -1652,22 +1728,22 @@ namespace FCalcACC
             }
         }
 
-        private void exitToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ExitToolStripMenuItem_Click(object sender, EventArgs e)
         {
             // menu->exit
 
             Application.Exit();
         }
 
-        private void helpToolStripMenuItem_Click(object sender, EventArgs e)
+        private void HelpToolStripMenuItem_Click(object sender, EventArgs e)
         {
             // help button, showing new window
 
-            Form2 form2 = new Form2();
+            Form2 form2 = new();
             form2.ShowDialog();
         }
 
-        private void checkBox_max_stint_Click(object sender, EventArgs e)
+        private void CheckBox_max_stint_Click(object sender, EventArgs e)
         {
             // checkBox max stint enables and disables textBox
 
@@ -1682,11 +1758,11 @@ namespace FCalcACC
             }
         }
 
-        private void gitHubToolStripMenuItem_Click(object sender, EventArgs e)
+        private void GitHubToolStripMenuItem_Click(object sender, EventArgs e)
         {
             // github button, opnes github website of this project in a browser
 
-            string github_url = "https:// github.com/LabuzPawel/FCalcACC";
+            string github_url = "https://github.com/LabuzPawel/FCalcACC";
             Process.Start(new ProcessStartInfo
             {
                 FileName = github_url,
@@ -1707,6 +1783,8 @@ namespace FCalcACC
 
         private void NumericUpDown_pit_strat_changes(object sender, EventArgs e)
         {
+            // this event needs a debounce, multiple fast clicks and changes overloads CPU
+
             recalculate_debouncer.Debouce(() =>
             {
                 new_list_of_laps_to_pit.Clear();
@@ -1720,7 +1798,7 @@ namespace FCalcACC
             });
         }
 
-        private void comboBox_pit_options_SelectedIndexChanged(object sender, EventArgs e)
+        private void ComboBox_pit_options_SelectedIndexChanged(object sender, EventArgs e)
         {
             // if 'no pit stops' selected -> reset pit stops panel
 
@@ -1737,7 +1815,7 @@ namespace FCalcACC
             }
         }
 
-        private void resetAllDataToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ResetAllDataToolStripMenuItem_Click(object sender, EventArgs e)
         {
             // menu->reset data->reset current cat/track, option to reset data just for the selected car and track combination
 
@@ -1750,7 +1828,7 @@ namespace FCalcACC
             }
         }
 
-        private void resetCurrentCartrackToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ResetCurrentCartrackToolStripMenuItem_Click(object sender, EventArgs e)
         {
             // menu->reset data->reset all data, option to reset FCalcACC_data.json
 

--- a/FCalcACC/Form1.cs
+++ b/FCalcACC/Form1.cs
@@ -1,6 +1,5 @@
 using Newtonsoft.Json;
 using System.Diagnostics;
-using System.DirectoryServices;
 using System.Globalization;
 using System.Reflection;
 
@@ -31,7 +30,7 @@ namespace FCalcACC
 
         public int GetTankCapacity(string carName, string trackName)
         {
-            if (carName == "CAR" || trackName == "TRACK")
+            if (carName == "CAR" || trackName == "TRACK" || carName == "" || trackName == "")
             {
                 return 99999;
             }
@@ -64,7 +63,7 @@ namespace FCalcACC
         public int number_of_pits;
         public double formation_lap_fuel;
         private double fuel_for_race;
-        private Debouncer recalculate_debouncer = new Debouncer(100);
+        private Debouncer recalculate_debouncer = new Debouncer(50);
 
         bool is_strat_ok = true;
         private bool is_recalculate_needed = true;
@@ -85,9 +84,12 @@ namespace FCalcACC
 
         class Debouncer
         {
+            // https://stackoverflow.com/a/47933557
+
             private List<CancellationTokenSource> StepperCancelTokens = new List<CancellationTokenSource>();
             private int MillisecondsToWait;
-            private readonly object _lockThis = new object(); // Use a locking object to prevent the debouncer to trigger again while the func is still running
+            private readonly object _lockThis = new object(); // Use a locking object to prevent the debouncer
+                                                              // to trigger again while the func is still running
 
             public Debouncer(int millisecondsToWait = 300)
             {
@@ -128,9 +130,9 @@ namespace FCalcACC
             }
         }
 
-            public void LoadCarTrackObjects()
+        public void LoadCarTrackObjects()
         {
-            //Load Cars from embedded json's
+            // Load Cars from embedded json's
             string cars_resourse_name = "FCalcACC.car_track_data.CARS.json";
             string tracks_resourse_name = "FCalcACC.car_track_data.TRACKS.json";
             Assembly assembly = Assembly.GetExecutingAssembly();
@@ -141,7 +143,7 @@ namespace FCalcACC
                 all_cars = JsonConvert.DeserializeObject<List<Car>>(cars_embedded);
             }
 
-            //Load Track objects, if no data file then load from embedded
+            // Load Track objects, if no data file then load from embedded
             if (File.Exists("FCalcACC_data.json") == false)
             {
                 using (Stream stream = assembly.GetManifestResourceStream(tracks_resourse_name))
@@ -160,7 +162,7 @@ namespace FCalcACC
                 }
                 catch (Exception ex)
                 {
-                    //catch exception when data file is corrupted or unreadable
+                    // catch exception when data file is corrupted or unreadable
 
                     MessageBox.Show("Error reading FCalcACC_data.json:\n" + ex.Message, "Error",
                         MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -184,6 +186,7 @@ namespace FCalcACC
         {
             if (comboBoxCar.Text == "CAR" || comboBoxTrack.Text == "TRACK")
             {
+                // works only if there is a specific car AND track selected
                 return;
             }
 
@@ -198,7 +201,7 @@ namespace FCalcACC
                     string tracks_embedded = reader.ReadToEnd();
                     List<Track> temp_tracks = JsonConvert.DeserializeObject<List<Track>>(tracks_embedded);
 
-                    //Find the specific track in the list
+                    // Find the specific track in the list
                     Track default_track = temp_tracks.Find(t => t.track_name == comboBoxTrack.Text);
                     CarTrackFuel default_car_track_fuel = default_track.car_track_fuel.Find(
                         c => c.car_name == comboBoxCar.Text);
@@ -207,7 +210,7 @@ namespace FCalcACC
                         if (track.track_name.Equals(comboBox_track.Text))
                         {
                             track.track_lap_time = default_track.track_lap_time;
-                            
+
                             foreach (var car_fuel in track.car_track_fuel)
                             {
                                 if (car_fuel.car_name.Equals(comboBox_car.Text))
@@ -221,7 +224,7 @@ namespace FCalcACC
             }
             catch (Exception ex)
             {
-                // Handle exceptions
+                //  Handle exceptions
                 MessageBox.Show("Error reading FCalcACC_data.json:\n" + ex.Message, "Error",
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
 
@@ -287,11 +290,11 @@ namespace FCalcACC
 
         private void comboBox_class_SelectedIndexChanged(object sender, EventArgs e)
         {
-            //Load cars from selected class when comboBox_class changes
+            // Load cars from selected class when comboBox_class changes
             LoadCars(comboBox_car, comboBox_class.Text);
         }
 
-        //Restrictions to key presses in textBoxes, numericUpDowns
+        // Restrictions to key presses in textBoxes, numericUpDowns
         private void textBox_race_h_KeyPress(object sender, KeyPressEventArgs e)
         {
             e.Handled = !char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar);
@@ -331,14 +334,14 @@ namespace FCalcACC
         {
             if (number_of_pits > 0 && comboBoxPitOptions.SelectedIndex == -1)
             {
-                //change to default pit option (tires and fuel) if nothing is selected AND
-                //number of pits is different than 0
+                // change to default pit option (tires and fuel) if nothing is selected AND
+                // number of pits is different than 0
                 comboBoxPitOptions.SelectedIndex = 3;
             }
 
             if (selected_track == "TRACK")
             {
-                //calculate time lost in pits when track ISNT selected
+                // calculate time lost in pits when track ISNT selected
 
                 switch (comboBoxPitOptions.Text)
                 {
@@ -362,7 +365,7 @@ namespace FCalcACC
             }
             else
             {
-                //calculate time lost in pits when track IS selected
+                // calculate time lost in pits when track IS selected
 
                 var selected_track_object = all_tracks.FirstOrDefault(track => track.track_name.Contains(selected_track));
                 int.TryParse(selected_track_object.track_pit_duration, out time_in_pits);
@@ -391,13 +394,13 @@ namespace FCalcACC
 
         public void RefuelTimeLost(string selected_track, NumericUpDown numericUpDownPits)
         {
-            //funtion used when 'refuel only' is selected in pit options
-            //time lost depends of liters during refuel
+            // funtion used when 'refuel only' is selected in pit options
+            // time lost depends of liters during refuel
 
             number_of_pits = (int)numericUpDownPits.Value;
 
-            //this statement is needed to skip this function in a situation when number of pits is unknown (0) and
-            //will change at the start of CalculatePitStops
+            // this statement is needed to skip this function in a situation when number of pits is unknown (0) and
+            // will change at the start of CalculatePitStops
             if (number_of_pits == 0)
             {
                 return;
@@ -406,13 +409,13 @@ namespace FCalcACC
             int time_in_pits;
             if (selected_track != "TRACK")
             {
-                //when track IS selected
+                // when track IS selected
                 var selected_track_object = all_tracks.FirstOrDefault(track => track.track_name.Contains(selected_track));
                 int.TryParse(selected_track_object.track_pit_duration, out time_in_pits);
             }
             else
             {
-                //when track ISNT selected
+                // when track ISNT selected
                 time_in_pits = DEFAULT_TIME_IN_PITS;
             }
 
@@ -436,20 +439,30 @@ namespace FCalcACC
         public void CalculateRaceDuration(TextBox TextBoxRaceH, TextBox textBoxRaceMin, TextBox textBoxLapMin,
             TextBox textBoxLapSec, Label labelOverallResult, Label labelLapsResult, Label labelLapTimeResult2)
         {
-            //calculates overall race duration based on how many laps with a given lap time
-            //will be before end of the race, time lost in pits is added at the start
+            // calculates overall race duration based on how many laps with a given lap time
+            // will be before end of the race, time lost in pits is added at the start
 
             int.TryParse(TextBoxRaceH.Text, out int h_race);
             int.TryParse(textBoxRaceMin.Text, out int min_race);
+
             if (min_race > 59)
             {
-                //if someone iserts more than 59mins then set 59
+                // if someone iserts more than 59 mins then set 59
                 min_race = 59;
                 textBoxRaceMin.Text = min_race.ToString();
             }
 
-            //make sure that it doesnt matter if decimal separator is . or ,
-            //when more than one separator deletes all decimal separators except the first one
+            if (h_race > 24)
+            {
+                // if someone iserts more than 24h then set 24 for hours and 0 for mins
+                h_race = 24;
+                TextBoxRaceH.Text = h_race.ToString();
+                min_race = 0;
+                textBoxRaceMin.Text = min_race.ToString();
+            }
+
+            // make sure that it doesnt matter if decimal separator is . or ,
+            // when more than one separator -> deletes all decimal separators except the first one
             string lap_time_sec_normalize = textBoxLapSec.Text.Replace(".", DECIMAL_SEPARATOR).Replace(",", DECIMAL_SEPARATOR);
             int decimal_separator_count = 0;
             foreach (char d in lap_time_sec_normalize)
@@ -469,18 +482,18 @@ namespace FCalcACC
             int.TryParse(textBoxLapMin.Text, out int min_laptime);
             if (min_laptime > 59)
             {
-                //if someone iserts more than 59mins then set 59
+                // if someone iserts more than 59mins then set 59
                 min_laptime = 59;
                 textBoxLapMin.Text = min_laptime.ToString();
             }
             if (sec_laptime > 59.99999)
             {
-                //if someone iserts more than 59.999secs then set 59.999
+                // if someone iserts more than 59.999secs then set 59.999
                 sec_laptime = 59.999f;
                 textBoxLapSec.Text = sec_laptime.ToString();
             }
 
-            //fill label in results with user lap time
+            // fill label in results with user lap time
             int lap_time_secs_floor = (int)Math.Floor(sec_laptime);
             int lap_time_secs_rest = (int)Math.Round((sec_laptime - lap_time_secs_floor) * 1000);
             string formatted_lap_time = string.Format("{0:D1}:{1:D2}.{2:000}",
@@ -490,22 +503,22 @@ namespace FCalcACC
             race_duration_secs = (h_race * 3600) + (min_race * 60);
             lap_time_secs = (min_laptime * 60) + sec_laptime;
 
-            //overall race duration starts with time lost in pits
+            // overall race duration starts with time lost in pits
             overall_race_duration = time_lost_in_pits;
 
             number_of_laps = 0;
 
-            //add lap times until threshold of race duration is crossed
+            // add lap times until threshold of race duration is crossed
             while (overall_race_duration < race_duration_secs)
             {
                 overall_race_duration += lap_time_secs;
                 number_of_laps++;
             }
 
-            //fill label in results with number of laps
+            // fill label in results with number of laps
             labelLapsResult.Text = number_of_laps.ToString();
 
-            //fill label in results with overall race duration
+            // fill label in results with overall race duration
             TimeSpan time_interval = TimeSpan.FromSeconds(overall_race_duration);
             string formatted_overall_duration = string.Format("{0:D2}:{1:D2}:{2:D2}",
                 (int)time_interval.TotalHours, time_interval.Minutes, time_interval.Seconds);
@@ -515,7 +528,7 @@ namespace FCalcACC
 
         public void CalculateLapTimePlusMinus(Label labelPlus1LapTimeResult, Label labelMinus1LapTimeResult)
         {
-            //calculates lap times that are needed for the race to be one lap longer and shorter
+            // calculates lap times that are needed for the race to be one lap longer and shorter
 
             double plus1_lap_time_secs = lap_time_secs - ((overall_race_duration - race_duration_secs) / number_of_laps);
             int plus1_lap_time_floor = (int)Math.Floor(plus1_lap_time_secs);
@@ -537,10 +550,10 @@ namespace FCalcACC
         public void CalculateFuel(TextBox textBoxFuelPerLap, ListBox listBoxformationLap, Label labelFuelRaceResult,
             Label labelPlus1FuelResult, Label labelMinus1FuelResult)
         {
-            //calculates fuel for the race based on number of laps and formation lap
+            // calculates fuel for the race based on number of laps and formation lap
 
-            //make sure that it doesnt matter if decimal separator is . or ,
-            //when more than one separator deletes all decimal separators except the first one
+            // make sure that it doesnt matter if decimal separator is . or ,
+            // when more than one separator deletes all decimal separators except the first one
             string fuel_per_lap_normalize = textBoxFuelPerLap.Text.Replace(".", DECIMAL_SEPARATOR).Replace(",", DECIMAL_SEPARATOR);
             int decimal_separator_count = 0;
             foreach (char d in fuel_per_lap_normalize)
@@ -562,8 +575,8 @@ namespace FCalcACC
             double brake_dragging_full = 0;
             double brake_dragging_short = 0;
 
-            //taking into account that formation lap can use a bit more fuel while
-            //heating up tires with brake dragging
+            // taking into account that formation lap can use a bit more fuel while
+            // heating up tires with brake dragging
             if (full_formation_lap)
             {
                 brake_dragging_full = fuel_per_lap + (fuel_per_lap * 0.1);
@@ -574,7 +587,7 @@ namespace FCalcACC
             }
             formation_lap_fuel = brake_dragging_full + brake_dragging_short;
 
-            //fill labels in results with fuel amounts
+            // fill labels in results with fuel amounts
             fuel_for_race = (number_of_laps * (fuel_per_lap + 0.01)) + formation_lap_fuel;
             fuel_for_race_round_up = (int)Math.Ceiling(fuel_for_race);
             labelFuelRaceResult.Text = fuel_for_race_round_up.ToString() + " L";
@@ -592,15 +605,15 @@ namespace FCalcACC
             ComboBox comboBoxPitOptions, out string labelFuelStartResultText, out List<int> fuelPerStint,
             out List<int> lapsPerStint, List<int> newListOfLapsToPit)
         {
-            //calculate pit stop strategy based on number of pit stops, pit options, max stint duration, tank capacity etc.
+            // calculate pit stop strategy based on number of pit stops, pit options, max stint duration, tank capacity etc.
 
             dynamic_numericUpDowns.Clear();
             dynamic_labels.Clear();
 
-            //clear pit stop panel from previous calculation
+            // clear pit stop panel from previous calculation
             panelPitStopStrategy.Controls.Clear();
 
-            //groupBox for the start of the race
+            // groupBox for the start of the race
             GroupBox groupBox_start = new GroupBox();
             groupBox_start.Text = "Stint 1 - Start of the race";
             groupBox_start.BackColor = Color.Gainsboro;
@@ -610,7 +623,7 @@ namespace FCalcACC
             groupBox_start.Size = groupBox_size;
             panelPitStopStrategy.Controls.Add(groupBox_start);
 
-            //tableLayout with results for groupBox above
+            // tableLayout with results for groupBox above
             TableLayoutPanel tableLayoutPanel_start = new TableLayoutPanel();
             tableLayoutPanel_start.Size = new Size(350, 32);
             tableLayoutPanel_start.CellBorderStyle = TableLayoutPanelCellBorderStyle.Outset;
@@ -622,7 +635,7 @@ namespace FCalcACC
             tableLayoutPanel_start.Location = new Point(15, 35);
             groupBox_start.Controls.Add(tableLayoutPanel_start);
 
-            //labels that are inside tableLayout above
+            // labels that are inside tableLayout above
             Label label_fuel_for_start = new Label();
             label_fuel_for_start.Text = "Fuel for the start";
             label_fuel_for_start.Dock = DockStyle.Fill;
@@ -640,8 +653,7 @@ namespace FCalcACC
 
             number_of_pits = (int)numericUpDownPits.Value;
 
-            //fuelPerStint, lapsPerStint, labelFuelStartResultText are for testing purposes right now
-            //lists might be used in future for recalculating pit stop strategy
+            // fuelPerStint, lapsPerStint, labelFuelStartResultText are for testing purposes
             fuelPerStint = new List<int>();
             lapsPerStint = new List<int>();
             labelFuelStartResultText = "";
@@ -650,8 +662,8 @@ namespace FCalcACC
 
             if (comboBox_car.Text == "CAR" || comboBox_track.Text == "TRACK")
             {
-                //tank capacity is unknown when no car or track is selected but it is require for calculation
-                //set big amount of tank_capacity so tank isnt a limiting factor
+                // tank capacity is unknown when no car or track is selected but it is require for calculation
+                // set big amount of tank_capacity so tank isnt a limiting factor
                 tank_capacity = 999999;
             }
             else
@@ -659,10 +671,10 @@ namespace FCalcACC
                 tank_capacity = GetTankCapacity(comboBox_car.Text, comboBox_track.Text);
             }
 
-            //if number of pit stops is 0 but pit option and/or max stint duration selected then
-            //calculate number of pit stops needed (usefull if we dont know how many pits will fit into a longer race)
-            //and recalculate based on new information about number of pit stops
-            //'1L refuel' and 'tires only' pit options will get a logical in this case 1 pit stop
+            // if number of pit stops is 0 but pit option and/or max stint duration selected then
+            // calculate number of pit stops needed (usefull if we dont know how many pits will fit into a longer race)
+            // and recalculate based on new information about number of pit stops
+            // '1L refuel' and 'tires only' pit options will get a logical in this case 1 pit stop
             if (comboBoxPitOptions.SelectedIndex != -1 && checkBox_max_stint.Checked == false &&
                 numericUpDownPits.Value == 0)
             {
@@ -677,8 +689,8 @@ namespace FCalcACC
                 {
                     number_of_pits = fuel_for_race_round_up / tank_capacity;
 
-                    //even if result above is 0 (tank capacity is more than enough for whole race)
-                    //but pit option is selected then add one pit stop
+                    // even if result above is 0 (tank capacity is more than enough for whole race)
+                    // but pit option is selected then add one pit stop
                     if (number_of_pits == 0)
                     {
                         number_of_pits++;
@@ -692,7 +704,7 @@ namespace FCalcACC
             else if (comboBoxPitOptions.SelectedIndex != -1 && checkBox_max_stint.Checked == true &&
                 numericUpDownPits.Value == 0)
             {
-                //checking if number of pits will be limited by max stint duration or fuel tank
+                // checking if number of pits will be limited by max stint duration or fuel tank
                 int number_of_pits_stint = race_duration_secs / (int.Parse(textBox_max_stint.Text) * 60);
                 int number_of_pits_tank = number_of_laps / (int)Math.Ceiling(tank_capacity / fuel_per_lap);
                 number_of_pits = Math.Max(number_of_pits_tank, number_of_pits_stint);
@@ -702,8 +714,8 @@ namespace FCalcACC
                 return;
             }
 
-            //if a sum of max stint duration with a set number of pit stops isnt enough for a race
-            //recalculate number of pit stops
+            // if a sum of max stint duration with a set number of pit stops isnt enough for a race
+            // recalculate number of pit stops
             if ((number_of_pits + 1) * (int.Parse(textBox_max_stint.Text) * 60) < race_duration_secs &&
                 checkBox_max_stint.Checked == true)
             {
@@ -715,14 +727,14 @@ namespace FCalcACC
 
             if (number_of_pits == 0)
             {
-                //if number of pit stops is 0, then fill fuel label for the start of the race
-                //in first groupBox with fuel for whole race
+                // if number of pit stops is 0, then fill fuel label for the start of the race
+                // in first groupBox with fuel for whole race
 
                 label_fuel_start_result.Text = labelFuelRaceResult.Text;
                 labelFuelStartResultText = label_fuel_start_result.Text;
                 fuelPerStint.Add(fuel_for_race_round_up);
 
-                //warning if tank capacity is lower than fuel require for the race
+                // warning if tank capacity is lower than fuel require for the race
                 if (fuel_for_race_round_up > tank_capacity)
                 {
                     GroupBox groupBox_warning = new GroupBox();
@@ -747,21 +759,21 @@ namespace FCalcACC
             }
             else
             {
-                //set some variables before going into a pit stop loop
-                //'stint' is a number of laps between pit stops
+                // set some variables before going into a pit stop loop
+                // 'stint' is a period between pit stops
 
                 double current_laps = 0.0;
                 int stints_left = number_of_pits;
 
-                //number_of_laps_remaining holds a number of laps left after each stint
+                // number_of_laps_remaining holds a number of laps left after each stint
                 double laps_per_stint = (double)number_of_laps / (number_of_pits + 1);
                 double number_of_laps_remaining = number_of_laps;
 
-                //variable that will set location of grouBox below the previous one
+                // variable that will set location of grouBox below the previous one
                 int y_groupBox = 120;
 
-                //calculate fuel for the first stint and substract it from fuel for the whole race
-                //fuel_remaining will now holds a fuel that still needs to be add in next pit stop(s)
+                // calculate fuel for the first stint and substract it from fuel for the whole race
+                // fuel_remaining will now holds a fuel that still needs to be add in next pit stop(s)
                 int fuel_first_stint = (int)Math.Ceiling((laps_per_stint * fuel_per_lap) + formation_lap_fuel);
                 fuel_first_stint = Math.Min(fuel_first_stint, tank_capacity);
 
@@ -770,15 +782,16 @@ namespace FCalcACC
                 labelFuelStartResultText = fuel_first_stint.ToString() + " L";
                 fuelPerStint.Add(fuel_first_stint);
 
-                //stint's limiting factor is either tank capacity or max stint duration
+                // stint's limiting factor is either tank capacity or max stint duration
                 if (checkBox_max_stint.Checked == true && textBox_max_stint.Text != "0")
                 {
                     int laps_per_stint_tank = (int)(fuel_first_stint / fuel_per_lap);
                     int laps_per_stint_max = (int)((int.Parse(textBox_max_stint.Text)) * 60 / lap_time_secs);
-                    laps_per_stint = Math.Min(laps_per_stint_max, laps_per_stint_tank);
+                    int laps_per_stint_limit = Math.Min(laps_per_stint_max, laps_per_stint_tank);
+                    laps_per_stint = Math.Min(laps_per_stint_limit, laps_per_stint);
                 }
 
-                //variables that will be used when when 1L strategy isnt optimal
+                // variables that will be used when when 1L strategy isnt optimal
                 List<int> fuel_1L_adjusted = new List<int>();
                 int full_tank_count = fuel_for_race_round_up / tank_capacity;
                 int full_tank_sum = 0;
@@ -787,6 +800,18 @@ namespace FCalcACC
                 {
                     fuel_1L_adjusted.Add(tank_capacity);
                     full_tank_sum += tank_capacity;
+                }
+
+                if (number_of_pits < full_tank_count && is_strat_ok == false)
+                {
+                    number_of_pits += full_tank_count - 1;
+                    numericUpDownPits.Value = number_of_pits;
+                }
+
+                if (comboBoxPitOptions.Text == "1L refuel")
+                {
+                    laps_per_stint = (double)number_of_laps / (number_of_pits + 1);
+                    number_of_laps_remaining = number_of_laps;
                 }
 
                 int pit_stops_left = number_of_pits - full_tank_count;
@@ -800,11 +825,11 @@ namespace FCalcACC
                     fuel_1L_adjusted.Add(1);
                 }
 
-                //stint counter starts from 2 because 1st stint is already calculated by default in first groupBox
+                // stint counter starts from 2 because 1st stint is already calculated by default in first groupBox
                 int stint = 2;
                 for (int i = number_of_pits; i > 0; i--)
                 {
-                    //names for each groupBox changes with each stint
+                    // names for each groupBox changes with each stint
                     string name_for_groupbox = "groupBox_stint" + stint.ToString();
                     string name_for_refuel_label = "label_refuel_stint" + stint.ToString();
                     string name_for_refuel_result_label = "label_refuel_stint" + stint.ToString() + "_result";
@@ -812,8 +837,8 @@ namespace FCalcACC
 
                     if (comboBoxPitOptions.Text == "Tires only")
                     {
-                        //'tires only' means no refuel so fuel for the start is the same as for whole race
-                        //each loop iteration, groupBoxes are only fill with information about pit timing
+                        // 'tires only' means no refuel so fuel for the start is the same as for the whole race
+                        // each loop iteration, groupBoxes are only fill with information about pit timing
 
                         label_fuel_start_result.Text = label_fuel_race_result.Text;
 
@@ -864,8 +889,8 @@ namespace FCalcACC
                         stints_left--;
                         y_groupBox += 100;
 
-                        //on last loop iteration when all stint groupBoxes are done,
-                        //show a warning if tank capacity is lower than fuel for whole race
+                        // on last loop iteration when all stint groupBoxes are done,
+                        // show a warning if fuel tank capacity is lower than fuel for the whole race
                         if (fuel_for_race_round_up > tank_capacity && i == 1)
                         {
                             GroupBox groupBox_warning = new GroupBox();
@@ -890,17 +915,17 @@ namespace FCalcACC
                     }
                     else if (comboBoxPitOptions.Text == "1L refuel")
                     {
-                        //'1L refuel' pit options will attempt to set only 1L of refuel in each pit stop
-                        //'is_strat_ok' is used to switch to adjusted strategy if 1L per pit stop isnt enough of a refuel
+                        // '1L refuel' pit options will attempt to set only 1L of refuel in each pit stop
+                        // 'is_strat_ok' is used to switch to adjusted strategy if 1L per pit stop isnt enough of a refuel
                         is_strat_ok = true;
 
-                        //warning that strategy needs to be adjusted
+                        // warning that strategy needs to be adjusted
                         if (fuel_for_race_round_up > (tank_capacity + number_of_pits))
                         {
                             groupBox_start.Size = new Size(385, 123);
                             Label label_tank = new Label();
-                            label_tank.Text = "Exceeded fuel tank capacity of " + tank_capacity.ToString() + " L for 1L strategy. " +
-                                "Adjusted with higher refuel.";
+                            label_tank.Text = "Exceeded fuel tank capacity of " + tank_capacity.ToString() + 
+                                " L for 1L strategy. Adjusted with higher refuel.";
                             label_tank.Size = new Size(350, 50);
                             label_tank.Location = new Point(16, 74);
                             groupBox_start.Controls.Add(label_tank);
@@ -916,8 +941,8 @@ namespace FCalcACC
                         switch (is_strat_ok)
                         {
                             case true:
-                                //standard '1L refuel' strategy, 1L refuel each pit stop
-                                //number of pit stops (liters) are substrated from a fuel for a whole race
+                                // standard '1L refuel' strategy, 1L refuel each pit stop
+                                // number of pit stops (liters) are substrated from a fuel for the whole race
 
                                 label_fuel_start_result.Text = (fuel_for_race_round_up - number_of_pits).ToString() + " L";
 
@@ -984,10 +1009,10 @@ namespace FCalcACC
                                 break;
 
                             case false:
-                                //adjusted '1L refuel' strategy where more fuel is needed than with a standard approach
-                                //this version will attempt to have a pit stop with 1L
-                                //example: 1st stint = 120L, 2nd stint = 56L, 3rd stint = 1L
-                                //laps from each stint are being substracted from number_of_laps_remaining
+                                // adjusted '1L refuel' strategy where more fuel is needed than with a standard approach
+                                // this version will attempt to have a pit stop with 1L
+                                // example: 1st stint = 120L, 2nd stint = 56L, 3rd stint = 1L
+                                // laps from each stint are being substracted from number_of_laps_remaining
 
                                 label_fuel_start_result.Text = tank_capacity.ToString() + " L";
 
@@ -1039,7 +1064,7 @@ namespace FCalcACC
                                 numericUpDown_laps_temp2.Name = "numericUpDown_laps_stint" + stint.ToString();
                                 numericUpDown_laps_temp2.Dock = DockStyle.Fill;
                                 numericUpDown_laps_temp2.TextAlign = HorizontalAlignment.Center;
-                                numericUpDown_laps_temp2.Maximum = 999;
+                                numericUpDown_laps_temp2.Maximum = 9999;
                                 this.Controls.Add(numericUpDown_laps_temp2);
                                 dynamic_numericUpDowns.Add(numericUpDown_laps_temp2);
 
@@ -1050,6 +1075,8 @@ namespace FCalcACC
 
                                 numericUpDown_laps_temp2.Value = ((int)Math.Ceiling(current_laps));
 
+                                // numericUpDowns have to be locked when dealing with full tank so it makes sense
+                                // for this 1L strategy
                                 if (fuel_for_this_stint == tank_capacity || fuelPerStint[stint - 2] == tank_capacity)
                                 {
                                     numericUpDown_laps_temp2.Value = (int)(tank_capacity / fuel_per_lap) * (stint - 1);
@@ -1077,8 +1104,8 @@ namespace FCalcACC
                                 y_groupBox += 100;
                                 stint++;
 
-                                //recalculate everything on last loop is needed because time lost in pits
-                                //will change with this adjusted strategy
+                                // recalculate everything on last loop is needed because time lost in pits
+                                // will change with this adjusted strategy
                                 if (i == 1 && is_recalculate_needed == true)
                                 {
                                     time_lost_in_pits += more_time_in_pits;
@@ -1087,18 +1114,18 @@ namespace FCalcACC
                                     CalculateLapTimePlusMinus(label_plus1_lap_time_result, label_minus1_lap_time_result);
                                     CalculateFuel(textBox_fuel_per_lap, listBox_formation, label_fuel_race_result,
                                         label_plus1_fuel_result, label_minus1_fuel_result);
-                                    is_recalculate_needed = false;    //change to false so it wont be endless loop
+                                    is_recalculate_needed = false;    // change to false so it wont be endless loop
                                     CalculatePitStops(panel_pit_stop_strategy, label_fuel_race_result, numericUpDown_pits, comboBox_pit_options,
                                         out string labelFuelStartResultTextForTesting, out List<int> fuelPerStintForTesting,
                                         out List<int> lapsPitStintForTesting, new_list_of_laps_to_pit);
-                                    is_recalculate_needed = true;     //change back to true for next calculations
+                                    is_recalculate_needed = true;     // change back to true for next calculations
                                     SaveData();
                                 }
                                 break;
                         }
 
-                        //warning that for this number of pit stops with full tanks, its still not enough fuel
-                        //for the whole race
+                        // warning that for this number of pit stops with full tanks, its still not enough fuel
+                        // for the whole race
                         if (i == 1 && pit_stops_left < 0)
                         {
                             GroupBox groupBox_warning = new GroupBox();
@@ -1125,9 +1152,9 @@ namespace FCalcACC
                     }
                     else
                     {
-                        //'fixed refuel only', 'refuel only' and 'refuel + tires' share the same pit strategy formula
-                        //fuel from each stint is being substracted from fuel_remaining
-                        //laps from each stint are being substracted from number_of_laps_remaining
+                        // 'fixed refuel only', 'refuel only' and 'refuel + tires' share the same pit strategy formula
+                        // fuel from each stint is being substracted from fuel_remaining
+                        // laps from each stint are being substracted from number_of_laps_remaining
 
                         label_fuel_start_result.Text = fuel_first_stint.ToString() + " L";
 
@@ -1152,7 +1179,7 @@ namespace FCalcACC
                         numericUpDown_laps_temp.Name = "numericUpDown_laps_stint" + stint.ToString();
                         numericUpDown_laps_temp.Dock = DockStyle.Fill;
                         numericUpDown_laps_temp.TextAlign = HorizontalAlignment.Center;
-                        numericUpDown_laps_temp.Maximum = 999;
+                        numericUpDown_laps_temp.Maximum = 99999;
                         this.Controls.Add(numericUpDown_laps_temp);
                         dynamic_numericUpDowns.Add(numericUpDown_laps_temp);
 
@@ -1202,9 +1229,9 @@ namespace FCalcACC
                         y_groupBox += 112;
                         stint++;
 
-                        //warning that for this number of pit stops with full tanks, its still not enough fuel
-                        //for the whole race
-                        if (i == 1 && pit_stops_left < 0)
+                        // warning that for this number of pit stops with full tanks, its still not enough fuel
+                        // for the whole race
+                        if (i == 1 && pit_stops_left < 0 && full_tank_sum < fuel_for_race_round_up)
                         {
                             GroupBox groupBox_warning = new GroupBox();
                             groupBox_warning.Name = name_for_groupbox + "_warning";
@@ -1230,13 +1257,25 @@ namespace FCalcACC
                     }
                 }
             }
-            PitLimits();
+            foreach (NumericUpDown numericUpDown in dynamic_numericUpDowns)
+            {
+                int numeric_value = Convert.ToInt32((numericUpDown).Value);
+                new_list_of_laps_to_pit.Add(numeric_value);
+            };
+
+            PitLimits();    // set max and min limits on numericUpDowns
+
+            new_list_of_laps_to_pit.Clear();
         }
 
         private void Recalculate()
         {
+            // recalculate fuel when moving pit stops up and down in pit stop panel
+
             if (comboBox_pit_options.Text == "Tires only" || comboBox_pit_options.Text == "1L refuel")
             {
+                // Tires only and 1L refuel dont need a recalculation, only PitLimits
+
                 PitLimits();
                 return;
             }
@@ -1253,7 +1292,7 @@ namespace FCalcACC
 
                 for (int i = 1; i < dynamic_labels.Count; i++)
                 {
-                    if ( i != dynamic_labels.Count - 1)
+                    if (i != dynamic_labels.Count - 1)
                     {
                         current_laps = new_list_of_laps_to_pit[i] - new_list_of_laps_to_pit[i - 1];
                     }
@@ -1266,7 +1305,7 @@ namespace FCalcACC
 
                     int tank_capacity = GetTankCapacity(comboBox_car.Text, comboBox_track.Text);
 
-                    double current_part_fuel = Math.Min(fuel_remaining,(
+                    double current_part_fuel = Math.Min(fuel_remaining, (
                                     Math.Min((current_laps * fuel_per_lap) - rest_from_prev_stint, tank_capacity)));
                     rest_from_prev_stint = (int)Math.Ceiling(current_part_fuel) - current_part_fuel;
 
@@ -1274,33 +1313,36 @@ namespace FCalcACC
                     fuel_remaining -= fuel_for_this_stint;
 
                     dynamic_labels[i].Text = fuel_for_this_stint.ToString() + " L";
-                    int test = 0;
                 }
             }
-            PitLimits();
+
+            PitLimits();    // set NEW max and min limits on numericUpDowns
+
+            new_list_of_laps_to_pit.Clear();
         }
 
-    private void PitLimits()
+        private void PitLimits()
         {
+            // numericUpDowns need min and max limit to prevent moving the pit stop beyond practical feasibility
+
             if (number_of_pits == 0)
             {
                 return;
             }
 
-            //set a minimum and maximum for NumericUpDown
+            // set a minimum and maximum for NumericUpDowns
 
-            int max_stint_limit = 99999;
-            int tank_capacity = 99999;
+            int max_stint_limit = 99999;    // big number so it wont be a limit if there is no maximum stint timer
+            int tank_capacity = 99999;      // big number so it wont be a limit if there is no car and track selected
             List<int> tank_capacity_limit = new List<int>();
 
             if (comboBox_car.Text != "CAR" && comboBox_track.Text != "TRACK")
             {
-
                 if (comboBox_pit_options.Text != "Tires only")
                 {
                     tank_capacity = GetTankCapacity(comboBox_car.Text, comboBox_track.Text);
                 }
-                
+
                 tank_capacity_limit.Add((int)((tank_capacity - formation_lap_fuel) / fuel_per_lap));
 
                 int sum_of_prev_stints = 0;
@@ -1327,8 +1369,8 @@ namespace FCalcACC
                 max_stint_limit = (int)((max_stint * 60) / lap_time_secs);
             }
 
-            //first pit stop cant be earlier than after lap 1 (min) and later than next pit stop or
-            //2nd to last lap (max)
+            // first pit stop cant be earlier than after lap 1 (min) and later than next pit stop (max)
+            // fuel tank capacity and/or max stint timer might also be a limiting factor
 
             if (dynamic_numericUpDowns.Count > 1)
             {
@@ -1359,7 +1401,7 @@ namespace FCalcACC
                     Math.Min(tank_capacity_limit[0], max_stint_limit));
             }
 
-            //another pit stop thresholds are previous pit timing and next or 2nd to last lap
+            // another pit stop thresholds are previous pit timing and next one or 2nd to last lap
             if (new_list_of_laps_to_pit.Count > 1)
             {
                 for (int i = 1; i < new_list_of_laps_to_pit.Count; i++)
@@ -1415,7 +1457,7 @@ namespace FCalcACC
 
         private void LoadData()
         {
-            //load data into comboBoxes if track and optionally car are selected
+            // load data into comboBoxes if track and optionally car are selected
 
             if (comboBox_track.Text != "TRACK")
             {
@@ -1440,7 +1482,7 @@ namespace FCalcACC
 
         private void SaveData()
         {
-            //saves data to 'FCalcACC_data.json' (fuel per lap, lap times)
+            // saves data to 'FCalcACC_data.json' (fuel per lap, lap times)
 
             foreach (var track in all_tracks)
             {
@@ -1469,25 +1511,27 @@ namespace FCalcACC
 
         public void Form1_Load(object sender, EventArgs e)
         {
-            //actions taken on applications start
+            // actions taken on applications start
 
             LoadCarTrackObjects();
             LoadCarClasses(comboBox_class);
             LoadTracks(comboBox_track);
             LoadPitOptions(comboBox_pit_options, PIT_OPTIONS);
 
-            //default formation lap is 'Full'
+            // default formation lap is 'Full'
             listBox_formation.SelectedIndex = 0;
         }
 
         public void ChangeTextBoxColor(TextBox textBox)
         {
+            // textBox will flash red color
+
             Color original_color = textBox.BackColor;
 
             textBox.BackColor = Color.Red;
 
             System.Windows.Forms.Timer timer = new System.Windows.Forms.Timer();
-            timer.Interval = 800;
+            timer.Interval = 1000;
             timer.Tick += (sender, e) =>
             {
                 textBox.BackColor = original_color;
@@ -1499,6 +1543,8 @@ namespace FCalcACC
 
         private bool OnlyZeros(string text)
         {
+            // check if string consists only characters from the list below
+
             List<char> chars = new List<char> { '0', '.', ',' };
 
             foreach (char c in text)
@@ -1513,8 +1559,8 @@ namespace FCalcACC
 
         private void button_calculate_Click(object sender, EventArgs e)
         {
-            //if either lap time, fuel per lap or race duration is set to 0
-            //prevent further calculations and flash textBox(es) with red color
+            // if either lap time, fuel per lap or race duration is set to 0
+            // prevent further calculations and flash textBox(es) with red color
 
             bool only_zeros = false;
 
@@ -1545,12 +1591,12 @@ namespace FCalcACC
 
             if (comboBox_pit_options.Text == "Refuel only")
             {
-                //for 'refuel only' pit option, time lost in pits is unknown because it relies on how much fuel
-                //needs to be add during pit stop based on fuel for whole race and number of pit stops
-                //fuel for whole race is unknown until CalculateFuel
-                //in this case first iteration gets a default pit duration
-                //next iteration gets more accurate information thanks to RefuelTimeLost
-                //there are 3 iteration to make sure that end result is as close as possible to ideal one
+                // for 'refuel only' pit option, time lost in pits is unknown because it relies on how much fuel
+                // needs to be add during pit stop based on fuel for whole race and number of pit stops
+                // fuel for whole race is unknown until CalculateFuel
+                // in this case first iteration gets a default pit duration
+                // next iteration gets more accurate information thanks to RefuelTimeLost
+                // there are 3 iteration to make sure that end result is as close as possible to ideal one
 
                 time_lost_in_pits = 57 * number_of_pits;
                 for (int i = 3; i > 0; i--)
@@ -1565,7 +1611,7 @@ namespace FCalcACC
             }
             else
             {
-                //standard procedure when 'only refuel' ISNT selected
+                // standard procedure when 'only refuel' ISNT selected
 
                 CalculateTimeLostInPits((int)numericUpDown_pits.Value, comboBox_pit_options, comboBox_track.Text);
                 CalculateRaceDuration(textBox_race_h, textBox_race_min, textBox_lap_time_min, textBox_lap_time_sec,
@@ -1582,28 +1628,40 @@ namespace FCalcACC
 
         private void comboBox_car_SelectedIndexChanged(object sender, EventArgs e)
         {
-            //load new data when selected car changes
+            // load new data when selected car changes
 
             LoadData();
         }
 
         private void comboBox_track_SelectedIndexChanged(object sender, EventArgs e)
         {
-            //load new data when selected track changes
+            // load new data when selected track changes
 
             LoadData();
+
+            if (comboBox_track.Text == "Nordschleife")
+            {
+                // change formation lap automatically to short when Nordschleife is selected
+                // this track is usually set up with short formation lap
+
+                listBox_formation.SelectedIndex = 1;
+            }
+            else
+            {
+                listBox_formation.SelectedIndex = 0;
+            }
         }
 
         private void exitToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            //menu->exit
+            // menu->exit
 
             Application.Exit();
         }
 
         private void helpToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            //help button, showing new window
+            // help button, showing new window
 
             Form2 form2 = new Form2();
             form2.ShowDialog();
@@ -1611,7 +1669,7 @@ namespace FCalcACC
 
         private void checkBox_max_stint_Click(object sender, EventArgs e)
         {
-            //checkBox max stint enables and disables textBox
+            // checkBox max stint enables and disables textBox
 
             if (checkBox_max_stint.Checked == true)
             {
@@ -1626,9 +1684,9 @@ namespace FCalcACC
 
         private void gitHubToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            //github button, opnes github website of this project in a browser
+            // github button, opnes github website of this project in a browser
 
-            string github_url = "https://github.com/LabuzPawel/FCalcACC";
+            string github_url = "https:// github.com/LabuzPawel/FCalcACC";
             Process.Start(new ProcessStartInfo
             {
                 FileName = github_url,
@@ -1636,22 +1694,9 @@ namespace FCalcACC
             });
         }
 
-        private void resetDataToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            //menu->reset data, option to reset FCalcACC_data.json
-
-            DialogResult result = MessageBox.Show("Would you like to reset the 'FCalcACC_data.json'?",
-                        "Reset data", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-            if (result == DialogResult.Yes)
-            {
-                File.Delete("FCalcACC_data.json");
-                LoadCarTrackObjects();
-            }
-        }
-
         private void Form1_Shown(object sender, EventArgs e)
         {
-            //dialog pop up after Form is shown informing that the file was created
+            // dialog pop up after Form is shown informing that the file was created
 
             if (File.Exists("FCalcACC_data.json") == false)
             {
@@ -1662,24 +1707,22 @@ namespace FCalcACC
 
         private void NumericUpDown_pit_strat_changes(object sender, EventArgs e)
         {
-            //get updated list of laps when user wants to pit
-            new_list_of_laps_to_pit.Clear();
-
-            recalculate_debouncer.Debouce(() => {
+            recalculate_debouncer.Debouce(() =>
+            {
+                new_list_of_laps_to_pit.Clear();
                 foreach (NumericUpDown numericUpDown in dynamic_numericUpDowns)
                 {
                     int numeric_value = Convert.ToInt32((numericUpDown).Value);
                     new_list_of_laps_to_pit.Add(numeric_value);
                 };
-                Recalculate(); 
+                Recalculate();
+                new_list_of_laps_to_pit.Clear();
             });
-            
-            new_list_of_laps_to_pit.Clear();
         }
 
         private void comboBox_pit_options_SelectedIndexChanged(object sender, EventArgs e)
         {
-            //if 'no pit stops' selected -> reset pit stops panel
+            // if 'no pit stops' selected -> reset pit stops panel
 
             if (comboBox_pit_options.SelectedIndex == 5)
             {
@@ -1696,16 +1739,25 @@ namespace FCalcACC
 
         private void resetAllDataToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            File.Delete("FCalcACC_data.json");
-            LoadCarTrackObjects();
+            // menu->reset data->reset current cat/track, option to reset data just for the selected car and track combination
+
+            DialogResult result = MessageBox.Show("Would you like to reset the 'FCalcACC_data.json'?",
+                        "Reset data", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            if (result == DialogResult.Yes)
+            {
+                File.Delete("FCalcACC_data.json");
+                LoadCarTrackObjects();
+            }
         }
 
         private void resetCurrentCartrackToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            // menu->reset data->reset all data, option to reset FCalcACC_data.json
+
             ResetSpecficCarTrack(comboBox_car, comboBox_track);
-            LoadData();
+            LoadData();     // load reseted data and fill textBoxes with it
             CalculateRaceDuration(textBox_race_h, textBox_race_min, textBox_lap_time_min, textBox_lap_time_sec,
-                    label_overall_result, label_laps_result, label_lap_time_result2);
+                    label_overall_result, label_laps_result, label_lap_time_result2);   // SaveData needs lap_time_secs
             SaveData();
         }
     }

--- a/FCalcACC/Form1.cs
+++ b/FCalcACC/Form1.cs
@@ -730,6 +730,14 @@ namespace FCalcACC
                         table_temp.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
                         table_temp.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50f));
 
+                        NumericUpDown numericUpDown_laps_temp = new NumericUpDown();
+                        numericUpDown_laps_temp.Name = "numericUpDown_laps_stint" + stint.ToString();
+                        numericUpDown_laps_temp.Dock = DockStyle.Fill;
+                        numericUpDown_laps_temp.TextAlign = HorizontalAlignment.Center;
+                        numericUpDown_laps_temp.Maximum = 999;
+                        this.Controls.Add(numericUpDown_laps_temp);
+                        dynamic_numericUpDowns.Add(numericUpDown_laps_temp);
+
                         Label label_refuel_temp = new Label();
                         label_refuel_temp.Dock = DockStyle.Fill;
                         label_refuel_temp.TextAlign = ContentAlignment.MiddleCenter;
@@ -742,19 +750,34 @@ namespace FCalcACC
                         fuelPerStint.Add(0);
                         lapsPerStint.Add((int)Math.Ceiling(current_laps));
 
-                        Label label_refuel_result_temp = new Label();
-                        label_refuel_result_temp.Name = name_for_refuel_result_label;
-                        label_refuel_result_temp.Text = ((int)Math.Ceiling(current_laps)).ToString() + " laps";
-                        label_refuel_result_temp.Size = new Size(130, 17);
-                        label_refuel_result_temp.Dock = DockStyle.Fill;
-                        label_refuel_result_temp.TextAlign = ContentAlignment.MiddleCenter;
+                        if (newListOfLapsToPit.Count > 0)
+                        {
+                            //this handles situation when user changes pit stop timing
+
+                            if (stints_left > 1)
+                            {
+                                current_laps = newListOfLapsToPit[stint - 1] - newListOfLapsToPit[stint - 2];
+                            }
+                            else
+                            {
+                                current_laps = newListOfLapsToPit[stint - 2] - sum_of_laps_from_prev_iterations;
+                            }
+
+                            sum_of_laps_from_prev_iterations += (int)current_laps;
+                            numericUpDown_laps_temp.Value = newListOfLapsToPit[stint - 2];
+                        }
+                        else
+                        {
+                            numericUpDown_laps_temp.Value = ((int)Math.Ceiling(current_laps));
+                        }
 
                         table_temp.Controls.Add(label_refuel_temp, 0, 0);
-                        table_temp.Controls.Add(label_refuel_result_temp, 1, 0);
+                        table_temp.Controls.Add(numericUpDown_laps_temp, 1, 0);
                         table_temp.Size = tableLayoutPanel_start.Size;
 
                         groupBox_temp.Controls.Add(table_temp);
                         stint++;
+                        stints_left--;
                         y_groupBox += 100;
 
                         //on last loop iteration when all stint groupBoxes are done,
@@ -842,6 +865,9 @@ namespace FCalcACC
                                 numericUpDown_laps_temp.Name = "numericUpDown_laps_stint" + stint.ToString();
                                 numericUpDown_laps_temp.Dock = DockStyle.Fill;
                                 numericUpDown_laps_temp.TextAlign = HorizontalAlignment.Center;
+                                numericUpDown_laps_temp.Maximum = 999;
+                                this.Controls.Add(numericUpDown_laps_temp);
+                                dynamic_numericUpDowns.Add(numericUpDown_laps_temp);
 
                                 double current_part = Math.Min(number_of_laps_remaining, laps_per_stint);
                                 current_laps += current_part;
@@ -850,13 +876,23 @@ namespace FCalcACC
                                 {
                                     //this handles situation when user changes pit stop timing
 
-                                    current_laps = newListOfLapsToPit[stint - 1] - sum_of_laps_from_prev_iterations;
-                                    sum_of_laps_from_prev_iterations += (int)current_laps;
-                                }
-                                this.Controls.Add(numericUpDown_laps_temp);
-                                dynamic_numericUpDowns.Add(numericUpDown_laps_temp);
+                                    if (stints_left > 1)
+                                    {
+                                        current_laps = newListOfLapsToPit[stint - 1] - newListOfLapsToPit[stint - 2];
+                                    }
+                                    else
+                                    {
+                                        current_laps = newListOfLapsToPit[stint - 2] - sum_of_laps_from_prev_iterations;
+                                    }
 
-                                numericUpDown_laps_temp.Value = ((int)Math.Ceiling(current_laps));
+                                    sum_of_laps_from_prev_iterations += (int)current_laps;
+                                    numericUpDown_laps_temp.Value = newListOfLapsToPit[stint - 2];
+                                }
+                                else
+                                {
+                                    numericUpDown_laps_temp.Value = ((int)Math.Ceiling(current_laps));
+                                }
+
                                 number_of_laps_remaining -= laps_per_stint;
                                 lapsPerStint.Add((int)Math.Ceiling(current_laps));
 
@@ -880,6 +916,7 @@ namespace FCalcACC
 
                                 groupBox_temp.Controls.Add(table_temp);
                                 stint++;
+                                stints_left--;
                                 y_groupBox += 130;
                                 break;
 
@@ -924,18 +961,44 @@ namespace FCalcACC
                                 numericUpDown_laps_temp2.Name = "numericUpDown_laps_stint" + stint.ToString();
                                 numericUpDown_laps_temp2.Dock = DockStyle.Fill;
                                 numericUpDown_laps_temp2.TextAlign = HorizontalAlignment.Center;
+                                numericUpDown_laps_temp2.Maximum = 999;
+                                this.Controls.Add(numericUpDown_laps_temp2);
+                                dynamic_numericUpDowns.Add(numericUpDown_laps_temp2);
 
 
-                                //TO DO: IMPLEMENT A SITUATION WHERE USER CHANGES PIT STOP TIMING FOR STRAT NOT OK
+                                //TO DO:
+                                //
+                                //IMPLEMENT A SITUATION WHERE USER CHANGES PIT STOP TIMING FOR STRAT NOT OK
                                 //TANK CAPACITY AND CURRENT FUEL LIMITS POSSIBLE PIT STOP TIMING
                                 //MAYBE CHANGE THRESHOLDS WHEN STRAT NOT OK
 
 
                                 double current_part_laps = Math.Min(number_of_laps_remaining, laps_per_stint);
                                 current_laps += current_part_laps;
-                                label_refuel_temp2.Text = "Refuel after " + ((int)Math.Ceiling(current_laps)) + " laps";
+                                label_refuel_temp2.Text = "Refuel after ";
                                 number_of_laps_remaining -= laps_per_stint;
                                 lapsPerStint.Add((int)Math.Ceiling(current_laps));
+
+                                if (newListOfLapsToPit.Count > 0)
+                                {
+                                    //this handles situation when user changes pit stop timing
+
+                                    if (stints_left > 1)
+                                    {
+                                        current_laps = newListOfLapsToPit[stint - 1] - newListOfLapsToPit[stint - 2];
+                                    }
+                                    else
+                                    {
+                                        current_laps = newListOfLapsToPit[stint - 2] - sum_of_laps_from_prev_iterations;
+                                    }
+
+                                    sum_of_laps_from_prev_iterations += (int)current_laps;
+                                    numericUpDown_laps_temp2.Value = newListOfLapsToPit[stint - 2];
+                                }
+                                else
+                                {
+                                    numericUpDown_laps_temp2.Value = ((int)Math.Ceiling(current_laps));
+                                }
 
                                 int fuel_for_this_stint = fuel_1L_adjusted[stint - 1];
                                 stints_left--;
@@ -1201,25 +1264,11 @@ namespace FCalcACC
             }
 
             //another pit stop thresholds are previous pit timing and next or 2nd to last lap
-            if (dynamic_numericUpDowns.Count > 1)
+            if (new_list_of_laps_to_pit.Count > 1)
             {
-                for (int i = 1; i < dynamic_numericUpDowns.Count; i++)
+                for (int i = 1; i < new_list_of_laps_to_pit.Count; i++)
                 {
-                    dynamic_numericUpDowns[i].Minimum = dynamic_numericUpDowns[i - 1].Value + 1;
-
-                    if (i < dynamic_numericUpDowns.Count - 1)
-                    {
-                        dynamic_numericUpDowns[i].Maximum = dynamic_numericUpDowns[i + 1].Value - 1;
-                    }
-                    else
-                    {
-                        dynamic_numericUpDowns[i].Maximum = number_of_laps - 1;
-                    }
-                }
-
-                for (int i = 1; i < dynamic_numericUpDowns.Count; i++)
-                {
-                    if (i > dynamic_numericUpDowns.Count - 1)
+                    if (i < new_list_of_laps_to_pit.Count - 1)
                     {
                         if (max_laps_in_stint > dynamic_numericUpDowns[i + 1].Value - dynamic_numericUpDowns[i].Value)
                         {
@@ -1241,8 +1290,17 @@ namespace FCalcACC
                     }
                     else
                     {
-                        dynamic_numericUpDowns[i].Minimum = number_of_laps - max_laps_in_stint;
-                        dynamic_numericUpDowns[i].Maximum = number_of_laps;
+                        dynamic_numericUpDowns[i].Minimum = Math.Max(number_of_laps - max_laps_in_stint, 
+                            dynamic_numericUpDowns[i - 1].Value + 1);
+
+                        if (max_laps_in_stint > dynamic_numericUpDowns[i].Value - dynamic_numericUpDowns[i - 1].Value)
+                        {
+                            dynamic_numericUpDowns[i].Maximum = number_of_laps - 1;
+                        }
+                        else
+                        {
+                            dynamic_numericUpDowns[i].Maximum = dynamic_numericUpDowns[i - 1].Value + max_laps_in_stint;
+                        }
                     }
                 }
             }

--- a/FCalcACC/car_track_data/CARS.json
+++ b/FCalcACC/car_track_data/CARS.json
@@ -1,214 +1,214 @@
 [
   {
-    "car_name": "Aston Martin V12 Vantage GT3 2013",
-    "class_name": "GT3"
+    "CarName": "Aston Martin V12 Vantage GT3 2013",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Aston Martin V8 Vantage GT3 2019",
-    "class_name": "GT3"
+    "CarName": "Aston Martin V8 Vantage GT3 2019",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Audi R8 LMS GT3 2015",
-    "class_name": "GT3"
+    "CarName": "Audi R8 LMS GT3 2015",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Audi R8 LMS Evo GT3 2019",
-    "class_name": "GT3"
+    "CarName": "Audi R8 LMS Evo GT3 2019",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Audi R8 LMS Evo II GT3 2022",
-    "class_name": "GT3"
+    "CarName": "Audi R8 LMS Evo II GT3 2022",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Bentley Continental GT3 2015",
-    "class_name": "GT3"
+    "CarName": "Bentley Continental GT3 2015",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Bentley Continental GT3 2018",
-    "class_name": "GT3"
+    "CarName": "Bentley Continental GT3 2018",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "BMW M6 GT3 2017",
-    "class_name": "GT3"
+    "CarName": "BMW M6 GT3 2017",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "BMW M4 GT3 2022",
-    "class_name": "GT3"
+    "CarName": "BMW M4 GT3 2022",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Emil Frey Jaguar GT3 2012",
-    "class_name": "GT3"
+    "CarName": "Emil Frey Jaguar GT3 2012",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Ferrari 488 GT3 2018",
-    "class_name": "GT3"
+    "CarName": "Ferrari 488 GT3 2018",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Ferrari 488 GT3 Evo 2020",
-    "class_name": "GT3"
+    "CarName": "Ferrari 488 GT3 Evo 2020",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Ferrari 296 GT3 2023",
-    "class_name": "GT3"
+    "CarName": "Ferrari 296 GT3 2023",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Honda NSX GT3 2017",
-    "class_name": "GT3"
+    "CarName": "Honda NSX GT3 2017",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Honda NSX Evo GT3 2019",
-    "class_name": "GT3"
+    "CarName": "Honda NSX Evo GT3 2019",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Lamborghini Huracan GT3 2015",
-    "class_name": "GT3"
+    "CarName": "Lamborghini Huracan GT3 2015",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Lamborghini Huracan Evo GT3 2019",
-    "class_name": "GT3"
+    "CarName": "Lamborghini Huracan Evo GT3 2019",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-    "class_name": "GT3"
+    "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Lexus RC F GT3 2016",
-    "class_name": "GT3"
+    "CarName": "Lexus RC F GT3 2016",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "McLaren 650S GT3 2015",
-    "class_name": "GT3"
+    "CarName": "McLaren 650S GT3 2015",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "McLaren 720S GT3 2019",
-    "class_name": "GT3"
+    "CarName": "McLaren 720S GT3 2019",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "McLaren 720S GT3 Evo 2023",
-    "class_name": "GT3"
+    "CarName": "McLaren 720S GT3 Evo 2023",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Mercedes AMG GT3 2015",
-    "class_name": "GT3"
+    "CarName": "Mercedes AMG GT3 2015",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Mercedes AMG GT3 2020",
-    "class_name": "GT3"
+    "CarName": "Mercedes AMG GT3 2020",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Nissan GTR Nismo GT3 2015",
-    "class_name": "GT3"
+    "CarName": "Nissan GTR Nismo GT3 2015",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Nissan GTR Nismo GT3 2018",
-    "class_name": "GT3"
+    "CarName": "Nissan GTR Nismo GT3 2018",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Porsche 911 GT3 R 2018",
-    "class_name": "GT3"
+    "CarName": "Porsche 911 GT3 R 2018",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Porsche 911 II GT3 R 2019",
-    "class_name": "GT3"
+    "CarName": "Porsche 911 II GT3 R 2019",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Porsche 992 GT3 R 2023",
-    "class_name": "GT3"
+    "CarName": "Porsche 992 GT3 R 2023",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Reiter Engineering R-EX GT3 2017",
-    "class_name": "GT3"
+    "CarName": "Reiter Engineering R-EX GT3 2017",
+    "ClassName": "GT3"
   },
   {
-    "car_name": "Audi R8 LMS GT2 2021",
-    "class_name": "GT2"
+    "CarName": "Audi R8 LMS GT2 2021",
+    "ClassName": "GT2"
   },
   {
-    "car_name": "KTM X-Bow GT2 2021",
-    "class_name": "GT2"
+    "CarName": "KTM X-Bow GT2 2021",
+    "ClassName": "GT2"
   },
   {
-    "car_name": "Maserati MC20 GT2 2023",
-    "class_name": "GT2"
+    "CarName": "Maserati MC20 GT2 2023",
+    "ClassName": "GT2"
   },
   {
-    "car_name": "Mercedes AMG GT2 2023",
-    "class_name": "GT2"
+    "CarName": "Mercedes AMG GT2 2023",
+    "ClassName": "GT2"
   },
   {
-    "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-    "class_name": "GT2"
+    "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+    "ClassName": "GT2"
   },
   {
-    "car_name": "Porsche 935 GT2 2019",
-    "class_name": "GT2"
+    "CarName": "Porsche 935 GT2 2019",
+    "ClassName": "GT2"
   },
   {
-    "car_name": "Alpine A110 GT4 2018",
-    "class_name": "GT4"
+    "CarName": "Alpine A110 GT4 2018",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "Aston Martin V8 Vantage GT4 2018",
-    "class_name": "GT4"
+    "CarName": "Aston Martin V8 Vantage GT4 2018",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "Audi R8 LMS GT4 2018",
-    "class_name": "GT4"
+    "CarName": "Audi R8 LMS GT4 2018",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "BMW M4 GT4 2018",
-    "class_name": "GT4"
+    "CarName": "BMW M4 GT4 2018",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "Chevrolet Camaro R GT4 2017",
-    "class_name": "GT4"
+    "CarName": "Chevrolet Camaro R GT4 2017",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "Ginetta G55 GT4 2012",
-    "class_name": "GT4"
+    "CarName": "Ginetta G55 GT4 2012",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "KTM X-Bow GT4 2016",
-    "class_name": "GT4"
+    "CarName": "KTM X-Bow GT4 2016",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "Maserati Granturismo MC GT4 2016",
-    "class_name": "GT4"
+    "CarName": "Maserati Granturismo MC GT4 2016",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "Mclaren 570S GT4 2016",
-    "class_name": "GT4"
+    "CarName": "Mclaren 570S GT4 2016",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "Mercedes AMG GT4 2016",
-    "class_name": "GT4"
+    "CarName": "Mercedes AMG GT4 2016",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-    "class_name": "GT4"
+    "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+    "ClassName": "GT4"
   },
   {
-    "car_name": "Ferrari 488 Challenge Evo 2020",
-    "class_name": "GTC"
+    "CarName": "Ferrari 488 Challenge Evo 2020",
+    "ClassName": "GTC"
   },
   {
-    "car_name": "Lamborghini Huracan Super Trofeo 2015",
-    "class_name": "GTC"
+    "CarName": "Lamborghini Huracan Super Trofeo 2015",
+    "ClassName": "GTC"
   },
   {
-    "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-    "class_name": "GTC"
+    "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+    "ClassName": "GTC"
   },
   {
-    "car_name": "Porsche 911 II GT3 Cup 2017",
-    "class_name": "GTC"
+    "CarName": "Porsche 911 II GT3 Cup 2017",
+    "ClassName": "GTC"
   },
   {
-    "car_name": "Porsche 911 GT3 Cup (992) 2021",
-    "class_name": "GTC"
+    "CarName": "Porsche 911 GT3 Cup (992) 2021",
+    "ClassName": "GTC"
   },
   {
-    "car_name": "BMW M2 CS 2020",
-    "class_name": "TCX"
+    "CarName": "BMW M2 CS 2020",
+    "ClassName": "TCX"
   }
 ]

--- a/FCalcACC/car_track_data/TRACKS.json
+++ b/FCalcACC/car_track_data/TRACKS.json
@@ -3265,272 +3265,272 @@
   },
   {
     "track_name": "Nordschleife",
-    "track_lap_time": "510",
+    "track_lap_time": "490",
     "track_pit_duration": "62",
     "car_track_fuel": [
       {
         "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "0",
-        "tank_capacity": "132"
+        "fuel_per_lap": "13.5",
+        "tank_capacity": "120"
       },
       {
         "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.5",
         "tank_capacity": "120"
       },
       {
         "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "0",
-        "tank_capacity": "106"
+        "fuel_per_lap": "13.0",
+        "tank_capacity": "120"
       },
       {
         "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.5",
         "tank_capacity": "120"
       },
       {
         "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "14.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "0",
-        "tank_capacity": "111"
+        "fuel_per_lap": "13.0",
+        "tank_capacity": "120"
       },
       {
         "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "0",
-        "tank_capacity": "132"
+        "fuel_per_lap": "13.0",
+        "tank_capacity": "120"
       },
       {
         "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "0",
-        "tank_capacity": "119"
+        "fuel_per_lap": "14.0",
+        "tank_capacity": "120"
       },
       {
         "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "110"
       },
       {
         "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "0",
-        "tank_capacity": "108"
+        "fuel_per_lap": "13.0",
+        "tank_capacity": "110"
       },
       {
         "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.5",
         "tank_capacity": "120"
       },
       {
         "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "108"
       },
       {
         "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "14.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "0",
-        "tank_capacity": "125"
+        "fuel_per_lap": "13.0",
+        "tank_capacity": "115"
       },
       {
         "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "0",
-        "tank_capacity": "108"
+        "fuel_per_lap": "13.0",
+        "tank_capacity": "120"
       },
       {
         "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "0",
-        "tank_capacity": "120"
+        "fuel_per_lap": "13.0",
+        "tank_capacity": "116"
       },
       {
         "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "0",
-        "tank_capacity": "132"
+        "fuel_per_lap": "13.5",
+        "tank_capacity": "120"
       },
       {
         "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "0",
-        "tank_capacity": "132"
+        "fuel_per_lap": "13.5",
+        "tank_capacity": "120"
       },
       {
         "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "0",
-        "tank_capacity": "103"
+        "fuel_per_lap": "13.0",
+        "tank_capacity": "120"
       },
       {
         "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.5",
         "tank_capacity": "120"
       },
       {
         "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "14.0",
         "tank_capacity": "130"
       },
       {
         "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "10.5",
         "tank_capacity": "95"
       },
       {
         "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "11.5",
         "tank_capacity": "120"
       },
       {
         "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "11.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "11.0",
         "tank_capacity": "127"
       },
       {
         "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "12.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "11.5",
         "tank_capacity": "107"
       },
       {
         "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "10.5",
         "tank_capacity": "120"
       },
       {
         "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "11.0",
         "tank_capacity": "110"
       },
       {
         "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "12.0",
         "tank_capacity": "110"
       },
       {
         "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "11.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "10.5",
         "tank_capacity": "115"
       },
       {
         "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.5",
         "tank_capacity": "120"
       },
       {
         "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "115"
       },
       {
         "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.5",
         "tank_capacity": "126"
       },
       {
         "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "13.0",
         "tank_capacity": "120"
       },
       {
         "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "12.5",
         "tank_capacity": "120"
       },
       {
         "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "12.0",
         "tank_capacity": "100"
       },
       {
         "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "10.0",
         "tank_capacity": "100"
       },
       {
         "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "0",
+        "fuel_per_lap": "9.5",
         "tank_capacity": "85"
       }
     ]

--- a/FCalcACC/car_track_data/TRACKS.json
+++ b/FCalcACC/car_track_data/TRACKS.json
@@ -1,6801 +1,6801 @@
 [
   {
-    "track_name": "Barcelona",
-    "track_lap_time": "103.5",
-    "track_pit_duration": "64",
-    "car_track_fuel": [
+    "TrackName": "Barcelona",
+    "TrackLapTime": "103.5",
+    "TrackPitDuration": "64",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.05",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.05",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "109"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "109"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.77",
-        "tank_capacity": "106"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.77",
+        "TankCapacity": "106"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.77",
-        "tank_capacity": "110"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.77",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "2.77",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "2.77",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "111"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "111"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.92",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.92",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "106"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "106"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "108"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "108"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "108"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "108"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.95",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.95",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "108"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "108"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "108"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "108"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "103"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "103"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.32",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.32",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.48",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.48",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.43",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.43",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.32",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.32",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.48",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.48",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.48",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.48",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "135"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "135"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Brands Hatch",
-    "track_lap_time": "83",
-    "track_pit_duration": "54",
-    "car_track_fuel": [
+    "TrackName": "Brands Hatch",
+    "TrackLapTime": "83",
+    "TrackPitDuration": "54",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.92",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.92",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.95",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.95",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "1.96",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "1.96",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.11",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.11",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.06",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.06",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.08",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.08",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "115"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "1.96",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "1.96",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.03",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.03",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.11",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.11",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.11",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.11",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "1.94",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "1.94",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.25",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "1.85",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "1.85",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "COTA",
-    "track_lap_time": "125.5",
-    "track_pit_duration": "69",
-    "car_track_fuel": [
+    "TrackName": "COTA",
+    "TrackLapTime": "125.5",
+    "TrackPitDuration": "69",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "106"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "106"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.42",
-        "tank_capacity": "110"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.42",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "115"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "106"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "106"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "114"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "114"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "114"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "110"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "107"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "2.56",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "2.56",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Donington Park",
-    "track_lap_time": "86",
-    "track_pit_duration": "55",
-    "car_track_fuel": [
+    "TrackName": "Donington Park",
+    "TrackLapTime": "86",
+    "TrackPitDuration": "55",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.18",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.18",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.18",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.18",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.42",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.42",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.42",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.42",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "2.33",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "2.33",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.34",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.34",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.25",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.88",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.88",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "2.56",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "2.56",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "1.75",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "1.75",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "1.9",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "1.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "1.9",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "1.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "1.85",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "1.85",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "1.96",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "1.96",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.05",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.05",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "1.77",
-        "tank_capacity": "100"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "1.77",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "1.78",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "1.78",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "1.95",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "1.95",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "1.9",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "1.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "1.77",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "1.77",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "1.48",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "1.48",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "1.5",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "1.5",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Hungaroring",
-    "track_lap_time": "104",
-    "track_pit_duration": "61",
-    "car_track_fuel": [
+    "TrackName": "Hungaroring",
+    "TrackLapTime": "104",
+    "TrackPitDuration": "61",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.82",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.82",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "2.95",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "2.95",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.71",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.71",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.62",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.62",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.62",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.62",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.62",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.62",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.79",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.79",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.71",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.71",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.71",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.71",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.64",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.64",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.64",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.64",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.15",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.15",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.32",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.32",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.28",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.28",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "115"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.15",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.15",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.32",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.32",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.32",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.32",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.25",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "2.95",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "2.95",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.0",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.0",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Imola",
-    "track_lap_time": "100",
-    "track_pit_duration": "74",
-    "car_track_fuel": [
+    "TrackName": "Imola",
+    "TrackLapTime": "100",
+    "TrackPitDuration": "74",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "3.15",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "3.15",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "3.15",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "3.15",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "3.15",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "3.15",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.43",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.43",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "3.43",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "3.43",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "3.36",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "3.36",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.82",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.82",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Indianapolis",
-    "track_lap_time": "95.8",
-    "track_pit_duration": "90",
-    "car_track_fuel": [
+    "TrackName": "Indianapolis",
+    "TrackLapTime": "95.8",
+    "TrackPitDuration": "90",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "113"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "113"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "113"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "113"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "116"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "116"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "115"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "114"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "118"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "118"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "114"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "114"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "110"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "114"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "107"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "2.56",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "2.56",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "112"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "112"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Kyalami",
-    "track_lap_time": "100.1",
-    "track_pit_duration": "55",
-    "car_track_fuel": [
+    "TrackName": "Kyalami",
+    "TrackLapTime": "100.1",
+    "TrackPitDuration": "55",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "113"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "113"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "113"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "113"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "114"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "114"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.95",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.95",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "110"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.48",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.48",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.43",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.43",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.32",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.32",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.48",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.48",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.48",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.48",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.31",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.31",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Laguna Seca",
-    "track_lap_time": "81.8",
-    "track_pit_duration": "63",
-    "car_track_fuel": [
+    "TrackName": "Laguna Seca",
+    "TrackLapTime": "81.8",
+    "TrackPitDuration": "63",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.05",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.05",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.15",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.15",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.15",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.15",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "1.96",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "1.96",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.11",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.11",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.06",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.06",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.08",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.08",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "1.96",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "1.96",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.11",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.11",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.11",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.11",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "1.94",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "1.94",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "1.9",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "1.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "1.9",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "1.9",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Misano",
-    "track_lap_time": "92.8",
-    "track_pit_duration": "74",
-    "car_track_fuel": [
+    "TrackName": "Misano",
+    "TrackLapTime": "92.8",
+    "TrackPitDuration": "74",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.49",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.49",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.49",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.49",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.66",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.66",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.66",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.66",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.71",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.71",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.76",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.76",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.76",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.76",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "2.83",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "2.83",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.28",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.28",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.23",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.23",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.25",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.25",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.28",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.28",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.28",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.28",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.12",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.12",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Monza",
-    "track_lap_time": "107",
-    "track_pit_duration": "65",
-    "car_track_fuel": [
+    "TrackName": "Monza",
+    "TrackLapTime": "107",
+    "TrackPitDuration": "65",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.67",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.67",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.23",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.23",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.23",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.23",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.23",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.23",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "3.46",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "3.46",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "3.29",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "3.29",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "3.29",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "3.29",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "3.73",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "3.73",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "3.66",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "3.66",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.66",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.66",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.66",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.66",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.96",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.96",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.92",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.92",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.94",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.94",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.96",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.96",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.96",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.96",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.78",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.78",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "3.46",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "3.46",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "3.46",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "3.46",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "3.46",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "3.46",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "3.46",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "3.46",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Mount Panorama",
-    "track_lap_time": "119.5",
-    "track_pit_duration": "60",
-    "car_track_fuel": [
+    "TrackName": "Mount Panorama",
+    "TrackLapTime": "119.5",
+    "TrackPitDuration": "60",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "3.75",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "3.75",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "3.75",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "3.75",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "4.2",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "4.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "4.2",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "4.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "4.1",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "4.1",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "3.95",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "3.95",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "4.46",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "4.46",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "3.18",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "3.18",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "3.22",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "3.22",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "4.05",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "4.05",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "4.2",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "4.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Nordschleife",
-    "track_lap_time": "488",
-    "track_pit_duration": "62",
-    "car_track_fuel": [
+    "TrackName": "Nordschleife",
+    "TrackLapTime": "488",
+    "TrackPitDuration": "62",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "13.5",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "13.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "13.5",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "13.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "13.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "13.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "14.0",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "14.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "14.0",
-        "tank_capacity": "120"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "14.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "13.5",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "13.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "108"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "108"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "14.0",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "14.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "115"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "116"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "116"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "13.5",
-        "tank_capacity": "120"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "13.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "13.5",
-        "tank_capacity": "120"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "13.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "13.5",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "13.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "14.0",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "14.0",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "10.5",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "10.5",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "11.5",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "11.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "11.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "11.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "11.0",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "11.0",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "12.0",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "12.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "11.5",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "11.5",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "10.5",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "10.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "11.0",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "11.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "12.0",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "12.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "11.0",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "11.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "10.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "10.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "13.5",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "13.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "13.5",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "13.5",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "13.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "13.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "12.5",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "12.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "12.0",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "12.0",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "10.0",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "10.0",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "9.5",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "9.5",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Nurburgring",
-    "track_lap_time": "113.1",
-    "track_pit_duration": "62",
-    "car_track_fuel": [
+    "TrackName": "Nurburgring",
+    "TrackLapTime": "113.1",
+    "TrackPitDuration": "62",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.36",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.36",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "106"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "106"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "3.27",
-        "tank_capacity": "111"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "3.27",
+        "TankCapacity": "111"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.88",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.88",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.88",
-        "tank_capacity": "108"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.88",
+        "TankCapacity": "108"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "3.04",
-        "tank_capacity": "108"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "3.04",
+        "TankCapacity": "108"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "3.04",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "3.04",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "3.04",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "3.04",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "3.24",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "3.24",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "108"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "108"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "3.16",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "3.16",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "3.16",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "3.16",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.33",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.33",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "3.26",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "3.26",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "103"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "103"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.72",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.72",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.68",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.68",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.76",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.76",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.76",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.76",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.72",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.72",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.72",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.72",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.59",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.59",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Oulton Park",
-    "track_lap_time": "92.8",
-    "track_pit_duration": "50",
-    "car_track_fuel": [
+    "TrackName": "Oulton Park",
+    "TrackLapTime": "92.8",
+    "TrackPitDuration": "50",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.42",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.42",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "2.59",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "2.59",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.15",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.15",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.25",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.25",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.44",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.44",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "2.42",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "2.42",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "2.73",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "2.73",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "1.9",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "1.9",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.05",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.05",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.05",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.05",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.0",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.0",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.11",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.11",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "1.92",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "1.92",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "1.93",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "1.93",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.11",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.11",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.05",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.05",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "1.92",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "1.92",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.25",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "1.65",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "1.65",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Paul Ricard",
-    "track_lap_time": "112.8",
-    "track_pit_duration": "65",
-    "car_track_fuel": [
+    "TrackName": "Paul Ricard",
+    "TrackLapTime": "112.8",
+    "TrackPitDuration": "65",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "3.26",
-        "tank_capacity": "113"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "3.26",
+        "TankCapacity": "113"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.18",
-        "tank_capacity": "112"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.18",
+        "TankCapacity": "112"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.18",
-        "tank_capacity": "112"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.18",
+        "TankCapacity": "112"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.18",
-        "tank_capacity": "114"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.18",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "3.23",
-        "tank_capacity": "117"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "3.23",
+        "TankCapacity": "117"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.65",
-        "tank_capacity": "115"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.65",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "113"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "113"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "119"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "112"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "112"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "114"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "3.44",
-        "tank_capacity": "113"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "3.44",
+        "TankCapacity": "113"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "3.42",
-        "tank_capacity": "115"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "3.42",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "109"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "109"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "3.66",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "3.66",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "3.33",
-        "tank_capacity": "115"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "3.33",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "3.33",
-        "tank_capacity": "112"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "3.33",
+        "TankCapacity": "112"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "120"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "120"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.61",
-        "tank_capacity": "107"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.61",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.66",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.66",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.67",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.67",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.82",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.82",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.78",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.78",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.67",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.67",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.82",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.82",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.82",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.82",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "3.46",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "3.46",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "3.46",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "3.46",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "3.46",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "3.46",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "3.46",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "3.46",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.2",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Red Bull Ring",
-    "track_lap_time": "88",
-    "track_pit_duration": "60",
-    "car_track_fuel": [
+    "TrackName": "Red Bull Ring",
+    "TrackLapTime": "88",
+    "TrackPitDuration": "60",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.67",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.67",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.66",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.66",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.56",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.56",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.73",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.73",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.06",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.06",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.16",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.16",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.18",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.18",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.24",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.24",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.27",
-        "tank_capacity": "115"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.27",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.06",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.06",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.24",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.24",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "1.94",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "1.94",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Silverstone",
-    "track_lap_time": "117.7",
-    "track_pit_duration": "59",
-    "car_track_fuel": [
+    "TrackName": "Silverstone",
+    "TrackLapTime": "117.7",
+    "TrackPitDuration": "59",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "3.36",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "3.36",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.18",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.18",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.18",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.18",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.18",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.18",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.65",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.65",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "3.23",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "3.23",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "3.23",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "3.23",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "3.23",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "3.23",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "3.44",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "3.44",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "3.42",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "3.42",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "4.2",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "4.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.96",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.96",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.91",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.91",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.96",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.96",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.96",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.96",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.78",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.78",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Snetterton",
-    "track_lap_time": "106",
-    "track_pit_duration": "53",
-    "car_track_fuel": [
+    "TrackName": "Snetterton",
+    "TrackLapTime": "106",
+    "TrackPitDuration": "53",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.57",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.57",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.67",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.67",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.88",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.88",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "2.67",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "2.67",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.04",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.04",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.19",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.19",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.15",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.15",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.23",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.23",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.07",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.07",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.08",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.08",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.25",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.25",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.07",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.07",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "1.9",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "1.9",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.0",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.0",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Spa-Francorchamps",
-    "track_lap_time": "135.8",
-    "track_pit_duration": "106",
-    "car_track_fuel": [
+    "TrackName": "Spa-Francorchamps",
+    "TrackLapTime": "135.8",
+    "TrackPitDuration": "106",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "4.37",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "4.37",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "115"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "108"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "108"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "114"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "114"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "4.1",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "4.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "4.08",
-        "tank_capacity": "112"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "4.08",
+        "TankCapacity": "112"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "4.2",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "4.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "4.6",
-        "tank_capacity": "115"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "4.6",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "4.1",
-        "tank_capacity": "119"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "4.1",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "4.3",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "4.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "4.24",
-        "tank_capacity": "108"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "4.24",
+        "TankCapacity": "108"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "4.24",
-        "tank_capacity": "117"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "4.24",
+        "TankCapacity": "117"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "4.24",
-        "tank_capacity": "114"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "4.24",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "4.23",
-        "tank_capacity": "113"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "4.23",
+        "TankCapacity": "113"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "4.15",
-        "tank_capacity": "115"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "4.15",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "4.1",
-        "tank_capacity": "109"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "4.1",
+        "TankCapacity": "109"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "4.1",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "4.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "4.05",
-        "tank_capacity": "116"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "4.05",
+        "TankCapacity": "116"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "4.05",
-        "tank_capacity": "114"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "4.05",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "4.3",
-        "tank_capacity": "120"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "4.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "4.25",
-        "tank_capacity": "120"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "4.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "4.2",
-        "tank_capacity": "115"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "4.2",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "104"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "104"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "4.4",
-        "tank_capacity": "120"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "4.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "3.43",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "3.43",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "3.45",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "3.45",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "120",
-        "tank_capacity": "3.25"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "120",
+        "TankCapacity": "3.25"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "3.23",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "3.23",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "4.1",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "4.1",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "4.3",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "4.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "4.4",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "4.4",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "4.2",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "4.2",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "4.2",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "4.2",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.95",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.95",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Suzuka",
-    "track_lap_time": "118.7",
-    "track_pit_duration": "61",
-    "car_track_fuel": [
+    "TrackName": "Suzuka",
+    "TrackLapTime": "118.7",
+    "TrackPitDuration": "61",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "3.55",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "3.55",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "3.15",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "3.15",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "3.7",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "3.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.93",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.93",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.9",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.9",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "3.75",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "3.75",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "4.3",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "4.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.72",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.72",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.68",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.68",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.76",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.76",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.76",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.76",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.61",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.61",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.72",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.72",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.72",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.72",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.72",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.72",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.59",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.59",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.65",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.65",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "4.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "4.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Valencia",
-    "track_lap_time": "90",
-    "track_pit_duration": "61",
-    "car_track_fuel": [
+    "TrackName": "Valencia",
+    "TrackLapTime": "90",
+    "TrackPitDuration": "61",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "115"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.35",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.35",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Watkins Glen",
-    "track_lap_time": "103",
-    "track_pit_duration": "69",
-    "car_track_fuel": [
+    "TrackName": "Watkins Glen",
+    "TrackLapTime": "103",
+    "TrackPitDuration": "69",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "113"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "113"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "112"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "112"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.42",
-        "tank_capacity": "112"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.42",
+        "TankCapacity": "112"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "114"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "115"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "112"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "112"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "115"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "3.25",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "3.25",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "114"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "119"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "114"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "114"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "114"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "113"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "113"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "115"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "109"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "109"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "116"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "116"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "3.6",
-        "tank_capacity": "114"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "3.6",
+        "TankCapacity": "114"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "120"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "120"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "115"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "107"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "3.35",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "3.35",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.8",
-        "tank_capacity": "120"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.3",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "3.4",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "3.4",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Zandvoort",
-    "track_lap_time": "95",
-    "track_pit_duration": "49",
-    "car_track_fuel": [
+    "TrackName": "Zandvoort",
+    "TrackLapTime": "95",
+    "TrackPitDuration": "49",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.82",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.82",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.65",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.65",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "2.95",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "2.95",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.55",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.55",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.66",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.66",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "3.1",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "3.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.62",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.62",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.79",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.79",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.66",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.66",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.66",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.66",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.64",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.64",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.64",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.64",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.85",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.85",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.9",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.9",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.28",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.28",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.23",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.23",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.25",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.25",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "120"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "107"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "107"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.13",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.13",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.28",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.28",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.28",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.28",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "2.12",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "2.12",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   },
   {
-    "track_name": "Zolder",
-    "track_lap_time": "87.6",
-    "track_pit_duration": "66",
-    "car_track_fuel": [
+    "TrackName": "Zolder",
+    "TrackLapTime": "87.6",
+    "TrackPitDuration": "66",
+    "CarTrackFuel": [
       {
-        "car_name": "Aston Martin V12 Vantage GT3 2013",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "132"
+        "CarName": "Aston Martin V12 Vantage GT3 2013",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT3 2019",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT3 2019",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo GT3 2019",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo GT3 2019",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS Evo II GT3 2022",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS Evo II GT3 2022",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT3 2015",
-        "fuel_per_lap": "2.45",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT3 2015",
+        "FuelPerLap": "2.45",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT3 2022",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "BMW M4 GT3 2022",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M6 GT3 2017",
-        "fuel_per_lap": "2.67",
-        "tank_capacity": "125"
+        "CarName": "BMW M6 GT3 2017",
+        "FuelPerLap": "2.67",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "Bentley Continental GT3 2015",
-        "fuel_per_lap": "2.66",
-        "tank_capacity": "132"
+        "CarName": "Bentley Continental GT3 2015",
+        "FuelPerLap": "2.66",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Bentley Continental GT3 2018",
-        "fuel_per_lap": "2.56",
-        "tank_capacity": "120"
+        "CarName": "Bentley Continental GT3 2018",
+        "FuelPerLap": "2.56",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Emil Frey Jaguar GT3 2012",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "119"
+        "CarName": "Emil Frey Jaguar GT3 2012",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "119"
       },
       {
-        "car_name": "Ferrari 296 GT3 2023",
-        "fuel_per_lap": "2.3",
-        "tank_capacity": "120"
+        "CarName": "Ferrari 296 GT3 2023",
+        "FuelPerLap": "2.3",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Ferrari 488 GT3 2018",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 2018",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Ferrari 488 GT3 Evo 2020",
-        "fuel_per_lap": "2.4",
-        "tank_capacity": "110"
+        "CarName": "Ferrari 488 GT3 Evo 2020",
+        "FuelPerLap": "2.4",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Honda NSX Evo GT3 2019",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX Evo GT3 2019",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Honda NSX GT3 2017",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "Honda NSX GT3 2017",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo GT3 2019",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo GT3 2019",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Evo2 GT3 2023",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Evo2 GT3 2023",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan GT3 2015",
-        "fuel_per_lap": "2.51",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan GT3 2015",
+        "FuelPerLap": "2.51",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lexus RC F GT3 2016",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lexus RC F GT3 2016",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "McLaren 650S GT3 2015",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "125"
+        "CarName": "McLaren 650S GT3 2015",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 2019",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "125"
+        "CarName": "McLaren 720S GT3 2019",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "125"
       },
       {
-        "car_name": "McLaren 720S GT3 Evo 2023",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "120"
+        "CarName": "McLaren 720S GT3 Evo 2023",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2015",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2015",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT3 2020",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT3 2020",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2015",
-        "fuel_per_lap": "2.75",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2015",
+        "FuelPerLap": "2.75",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Nissan GTR Nismo GT3 2018",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "132"
+        "CarName": "Nissan GTR Nismo GT3 2018",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "132"
       },
       {
-        "car_name": "Porsche 911 GT3 R 2018",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 GT3 R 2018",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 R 2019",
-        "fuel_per_lap": "2.73",
-        "tank_capacity": "120"
+        "CarName": "Porsche 911 II GT3 R 2019",
+        "FuelPerLap": "2.73",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 992 GT3 R 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 992 GT3 R 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Reiter Engineering R-EX GT3 2017",
-        "fuel_per_lap": "3.0",
-        "tank_capacity": "130"
+        "CarName": "Reiter Engineering R-EX GT3 2017",
+        "FuelPerLap": "3.0",
+        "TankCapacity": "130"
       },
       {
-        "car_name": "Alpine A110 GT4 2018",
-        "fuel_per_lap": "2.06",
-        "tank_capacity": "95"
+        "CarName": "Alpine A110 GT4 2018",
+        "FuelPerLap": "2.06",
+        "TankCapacity": "95"
       },
       {
-        "car_name": "Aston Martin V8 Vantage GT4 2018",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Aston Martin V8 Vantage GT4 2018",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Audi R8 LMS GT4 2018",
-        "fuel_per_lap": "2.16",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT4 2018",
+        "FuelPerLap": "2.16",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "BMW M4 GT4 2018",
-        "fuel_per_lap": "2.18",
-        "tank_capacity": "127"
+        "CarName": "BMW M4 GT4 2018",
+        "FuelPerLap": "2.18",
+        "TankCapacity": "127"
       },
       {
-        "car_name": "Chevrolet Camaro R GT4 2017",
-        "fuel_per_lap": "2.24",
-        "tank_capacity": "115"
+        "CarName": "Chevrolet Camaro R GT4 2017",
+        "FuelPerLap": "2.24",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ginetta G55 GT4 2012",
-        "fuel_per_lap": "2.24",
-        "tank_capacity": "115"
+        "CarName": "Ginetta G55 GT4 2012",
+        "FuelPerLap": "2.24",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "KTM X-Bow GT4 2016",
-        "fuel_per_lap": "2.06",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT4 2016",
+        "FuelPerLap": "2.06",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati Granturismo MC GT4 2016",
-        "fuel_per_lap": "2.24",
-        "tank_capacity": "110"
+        "CarName": "Maserati Granturismo MC GT4 2016",
+        "FuelPerLap": "2.24",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mclaren 570S GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "110"
+        "CarName": "Mclaren 570S GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "110"
       },
       {
-        "car_name": "Mercedes AMG GT4 2016",
-        "fuel_per_lap": "2.2",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT4 2016",
+        "FuelPerLap": "2.2",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 718 Cayman GT4 Clubsport 2019",
-        "fuel_per_lap": "1.94",
-        "tank_capacity": "115"
+        "CarName": "Porsche 718 Cayman GT4 Clubsport 2019",
+        "FuelPerLap": "1.94",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Audi R8 LMS GT2 2021",
-        "fuel_per_lap": "2.5",
-        "tank_capacity": "120"
+        "CarName": "Audi R8 LMS GT2 2021",
+        "FuelPerLap": "2.5",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "KTM X-Bow GT2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "KTM X-Bow GT2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Maserati MC20 GT2 2023",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "120"
+        "CarName": "Maserati MC20 GT2 2023",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Mercedes AMG GT2 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Mercedes AMG GT2 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 991 II GT2 RS CS Evo 2023",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Porsche 991 II GT2 RS CS Evo 2023",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 935 GT2 2019",
-        "fuel_per_lap": "3.5",
-        "tank_capacity": "115"
+        "CarName": "Porsche 935 GT2 2019",
+        "FuelPerLap": "3.5",
+        "TankCapacity": "115"
       },
       {
-        "car_name": "Ferrari 488 Challenge Evo 2020",
-        "fuel_per_lap": "2.8",
-        "tank_capacity": "126"
+        "CarName": "Ferrari 488 Challenge Evo 2020",
+        "FuelPerLap": "2.8",
+        "TankCapacity": "126"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo 2015",
-        "fuel_per_lap": "2.6",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo 2015",
+        "FuelPerLap": "2.6",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Lamborghini Huracan Super Trofeo Evo2 2021",
-        "fuel_per_lap": "2.7",
-        "tank_capacity": "120"
+        "CarName": "Lamborghini Huracan Super Trofeo Evo2 2021",
+        "FuelPerLap": "2.7",
+        "TankCapacity": "120"
       },
       {
-        "car_name": "Porsche 911 II GT3 Cup 2017",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 II GT3 Cup 2017",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "Porsche 911 GT3 Cup (992) 2021",
-        "fuel_per_lap": "2.86",
-        "tank_capacity": "100"
+        "CarName": "Porsche 911 GT3 Cup (992) 2021",
+        "FuelPerLap": "2.86",
+        "TankCapacity": "100"
       },
       {
-        "car_name": "BMW M2 CS 2020",
-        "fuel_per_lap": "2.1",
-        "tank_capacity": "85"
+        "CarName": "BMW M2 CS 2020",
+        "FuelPerLap": "2.1",
+        "TankCapacity": "85"
       }
     ]
   }

--- a/FCalcACC/car_track_data/TRACKS.json
+++ b/FCalcACC/car_track_data/TRACKS.json
@@ -3265,7 +3265,7 @@
   },
   {
     "track_name": "Nordschleife",
-    "track_lap_time": "490",
+    "track_lap_time": "488",
     "track_pit_duration": "62",
     "car_track_fuel": [
       {

--- a/FCalcACC/help.txt
+++ b/FCalcACC/help.txt
@@ -9,7 +9,7 @@ Additionaly it holds information about fuel tank capacity for every car and trac
 New data is being saved when user clicks on "Calculate" button.
 Every track also have unique time that is needed for full pit stop (tires change and refuel).
 
-To reset all data to its default values use "Reset data" in Menu strip.
+To reset all data or current car/track combination to its default values use Menu -> Reset Data.
 
 2. INPUT DATA
 
@@ -22,8 +22,8 @@ If no track is selected then time lost during pit stop is set to default. Defaul
 Variables section is required for calculation. Formation lap is set to 'Full' by default. Lap time should be an average time.
 
 Pit stop section is optional. If no pit option is selected and number of pits is more than 0, then tires + refuel is selected as default.
-If maximum stint duration and/or pit option are selected, require number of pits will be calculated automatically. 
-If number of pits isnt enough to cover the race with certain maximum stint duration, then additional pit(s) will be added.
+If maximum stint duration and/or pit option are selected, required number of pits will be calculated automatically. 
+If number of pits is not enough to cover the race with certain maximum stint duration, then additional pit(s) will be added.
 
 3. RESULTS
 
@@ -31,3 +31,5 @@ Row Lap time for +1 lap shows lap time that is needed for the race to have one m
 Row Lap time for -1 lap shows the opposite situation with race shorter by one lap.
 
 Pit stop panel will show a recommended pit stop strategy for the race, considering the selected pit stop option and the number of pit stops.
+If pit option is not "Tires only" or "1L refuel" then moving pit stops earlier/later than initially suggest will recalculate fuel needed for each stint.
+There are few limitations set that will prevent moving the pit stop beyond practical feasibility. Limiting factors are maximum stint timer, tank capacity or other pit stops.

--- a/FCalcACCFCalcACC.UnitTests/FCalcACC.UnitTests.cs
+++ b/FCalcACCFCalcACC.UnitTests/FCalcACC.UnitTests.cs
@@ -14,25 +14,25 @@ namespace FCalcACC.Tests
             form = new Form1();
         }
 
-        [TestMethod("Car object from CAR.json")]
+        [TestMethod("Car object from CARS.json")]
         public void LoadCarObjectList_LoadCarJson_ReturnsListOfCarObjects()
         {
             form.LoadCarTrackObjects();
             Assert.IsTrue(form.all_cars[0] is Car);
         }
 
-        [TestMethod("Track object from TRACK.json")]
+        [TestMethod("Track object from TRACKS.json")]
         public void LoadTrackObjectList_LoadTrackJson_ReturnsListOfTrackObjects()
         {
             form.LoadCarTrackObjects();
             Assert.IsTrue(form.all_tracks[0] is Track);
-            Assert.IsTrue(form.all_tracks[0].car_track_fuel[0] is CarTrackFuel);
+            Assert.IsTrue(form.all_tracks[0].CarTrackFuel[0] is CarTrackFuel);
         }
 
         [TestMethod("Load car classes into comboBox")]
         public void LoadCarClasses_AddUniqueCarClasses_ComboBoxCorrectlyPopulated()
         {
-            ComboBox comboBox_test = new ComboBox();
+            ComboBox comboBox_test = new();
             form.LoadCarTrackObjects();
 
             form.LoadCarClasses(comboBox_test);
@@ -47,31 +47,31 @@ namespace FCalcACC.Tests
         [TestMethod("Load cars based on selected car class")]
         public void LoadCars_AddCars_ComboBoxCorrectlyPopulated()
         {
-            ComboBox comboBox_test_car = new ComboBox();
+            ComboBox comboBox_test_car = new();
             form.LoadCarTrackObjects();
 
             form.LoadCars(comboBox_test_car, "GT3");
-            var gt3_cars = form.all_cars.Where(car => car.class_name.Contains("GT3"));
+            var gt3_cars = form.all_cars.Where(car => car.ClassName.Contains("GT3"));
             Assert.AreEqual(gt3_cars.Count(), comboBox_test_car.Items.Count);
             Assert.AreEqual(comboBox_test_car.Items[0], "Aston Martin V12 Vantage GT3 2013");
 
             form.LoadCars(comboBox_test_car, "GT4");
-            var gt4_cars = form.all_cars.Where(car => car.class_name.Contains("GT4"));
+            var gt4_cars = form.all_cars.Where(car => car.ClassName.Contains("GT4"));
             Assert.AreEqual(gt4_cars.Count(), comboBox_test_car.Items.Count);
             Assert.AreEqual(comboBox_test_car.Items[0], "Alpine A110 GT4 2018");
 
             form.LoadCars(comboBox_test_car, "GT2");
-            var gt2_cars = form.all_cars.Where(car => car.class_name.Contains("GT2"));
+            var gt2_cars = form.all_cars.Where(car => car.ClassName.Contains("GT2"));
             Assert.AreEqual(gt2_cars.Count(), comboBox_test_car.Items.Count);
             Assert.AreEqual(comboBox_test_car.Items[0], "Audi R8 LMS GT2 2021");
 
             form.LoadCars(comboBox_test_car, "GTC");
-            var gtc_cars = form.all_cars.Where(car => car.class_name.Contains("GTC"));
+            var gtc_cars = form.all_cars.Where(car => car.ClassName.Contains("GTC"));
             Assert.AreEqual(gtc_cars.Count(), comboBox_test_car.Items.Count);
             Assert.AreEqual(comboBox_test_car.Items[0], "Ferrari 488 Challenge Evo 2020");
 
             form.LoadCars(comboBox_test_car, "TCX");
-            var tcx_cars = form.all_cars.Where(car => car.class_name.Contains("TCX"));
+            var tcx_cars = form.all_cars.Where(car => car.ClassName.Contains("TCX"));
             Assert.AreEqual(tcx_cars.Count(), comboBox_test_car.Items.Count);
             Assert.AreEqual(comboBox_test_car.Items[0], "BMW M2 CS 2020");
         }
@@ -79,7 +79,7 @@ namespace FCalcACC.Tests
         [TestMethod("Load tracks into comboBox")]
         public void LoadTracks_AddTracks_ComboBoxCorrectlyPopulated()
         {
-            ComboBox comboBox_test = new ComboBox();
+            ComboBox comboBox_test = new();
             form.LoadCarTrackObjects();
             form.LoadTracks(comboBox_test);
 
@@ -90,8 +90,8 @@ namespace FCalcACC.Tests
         [TestMethod("Load pit options into comboBox")]
         public void LoadPitOptions_AddPitOptions_ComboBoxCorrectlyPopulated()
         {
-            ComboBox comboBox_test = new ComboBox();
-            form.LoadPitOptions(comboBox_test, form.PIT_OPTIONS);
+            ComboBox comboBox_test = new();
+            LoadPitOptions(comboBox_test, form.PIT_OPTIONS);
 
             Assert.AreEqual(form.PIT_OPTIONS.Count, comboBox_test.Items.Count);
             foreach (var option in form.PIT_OPTIONS)
@@ -103,8 +103,8 @@ namespace FCalcACC.Tests
         [TestMethod("Time lost in pits (No Track, 2 pits)")]
         public void CalculateTimeLostInPits_NoTrack2Pits()
         {
-            ComboBox comboBoxPitOptionsTest = new ComboBox();
-            form.LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
+            ComboBox comboBoxPitOptionsTest = new();
+            LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
 
             for (int i = 0; i < 5; i++)
             {
@@ -134,8 +134,8 @@ namespace FCalcACC.Tests
         [TestMethod("Time lost in pits (Selected Track, 2 pits)")]
         public void CalculateTimeLostInPits_SelectedTrack2Pits()
         {
-            ComboBox comboBoxPitOptionsTest = new ComboBox();
-            form.LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
+            ComboBox comboBoxPitOptionsTest = new();
+            LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
             form.LoadCarTrackObjects();
 
             for (int i = 0; i < 5; i++)
@@ -166,8 +166,7 @@ namespace FCalcACC.Tests
         [TestMethod("Calculating time lost in pits with only refuel #1 (No track selected, 1 pit)")]
         public void RefuelTimeLost_SampleData1()
         {
-            NumericUpDown numericUpDownPitsTest = new NumericUpDown();
-            numericUpDownPitsTest.Value = 1;
+            NumericUpDown numericUpDownPitsTest = new() { Value = 1 };
             form.time_lost_in_pits = 0;
             form.LoadCarTrackObjects();
             form.fuel_for_race_round_up = 104;
@@ -183,8 +182,7 @@ namespace FCalcACC.Tests
         [TestMethod("Calculating time lost in pits with only refuel #2 (Track selected, 4 pits)")]
         public void RefuelTimeLost_SampleData2()
         {
-            NumericUpDown numericUpDownPitsTest = new NumericUpDown();
-            numericUpDownPitsTest.Value = 4;
+            NumericUpDown numericUpDownPitsTest = new() { Value = 4 };
             form.time_lost_in_pits = 0;
             form.LoadCarTrackObjects();
             form.fuel_for_race_round_up = 104;
@@ -201,13 +199,13 @@ namespace FCalcACC.Tests
         public void CalculateRaceDuration_SampleData1()
         {
             form.time_lost_in_pits = form.DEFAULT_TIME_IN_PITS;
-            TextBox textBoxRaceHTest = new TextBox() { Text = "1" };
-            TextBox textBoxRaceMinTest = new TextBox() { Text = "0" };
-            TextBox textBoxLapMinTest = new TextBox() { Text = "1" };
-            TextBox textBoxLapSecTest = new TextBox() { Text = "45,5" };
-            Label labelLapsResultTest = new Label();
-            Label labelLapTimeResult2 = new Label();
-            Label labelOverallResultTest = new Label();
+            TextBox textBoxRaceHTest = new() { Text = "1" };
+            TextBox textBoxRaceMinTest = new() { Text = "0" };
+            TextBox textBoxLapMinTest = new() { Text = "1" };
+            TextBox textBoxLapSecTest = new() { Text = "45,5" };
+            Label labelLapsResultTest = new();
+            Label labelLapTimeResult2 = new();
+            Label labelOverallResultTest = new();
 
             form.CalculateRaceDuration(textBoxRaceHTest, textBoxRaceMinTest,
                 textBoxLapMinTest, textBoxLapSecTest, labelOverallResultTest, labelLapsResultTest, labelLapTimeResult2);
@@ -220,13 +218,13 @@ namespace FCalcACC.Tests
         public void CalculateRaceDuration_SampleData2()
         {
             form.time_lost_in_pits = form.DEFAULT_TIME_IN_PITS * 2;
-            TextBox textBoxRaceHTest = new TextBox() { Text = "0" };
-            TextBox textBoxRaceMinTest = new TextBox() { Text = "45" };
-            TextBox textBoxLapMinTest = new TextBox() { Text = "2" };
-            TextBox textBoxLapSecTest = new TextBox() { Text = "33,33,," };
-            Label labelLapsResultTest = new Label();
-            Label labelLapTimeResult2 = new Label();
-            Label labelOverallResultTest = new Label();
+            TextBox textBoxRaceHTest = new() { Text = "0" };
+            TextBox textBoxRaceMinTest = new() { Text = "45" };
+            TextBox textBoxLapMinTest = new() { Text = "2" };
+            TextBox textBoxLapSecTest = new() { Text = "33,33,," };
+            Label labelLapsResultTest = new();
+            Label labelLapTimeResult2 = new();
+            Label labelOverallResultTest = new();
 
             form.CalculateRaceDuration(textBoxRaceHTest, textBoxRaceMinTest,
                 textBoxLapMinTest, textBoxLapSecTest, labelOverallResultTest, labelLapsResultTest, labelLapTimeResult2);
@@ -243,8 +241,8 @@ namespace FCalcACC.Tests
             form.overall_race_duration = 3655.015;
             form.race_duration_secs = 3600;
             form.time_lost_in_pits = 0;
-            Label labelPlus1LapTimeResultTest = new Label();
-            Label labelMinus1LapTimeResultTest = new Label();
+            Label labelPlus1LapTimeResultTest = new();
+            Label labelMinus1LapTimeResultTest = new();
 
             form.CalculateLapTimePlusMinus(labelPlus1LapTimeResultTest, labelMinus1LapTimeResultTest);
 
@@ -260,8 +258,8 @@ namespace FCalcACC.Tests
             form.overall_race_duration = 7258.111;
             form.race_duration_secs = 7200;
             form.time_lost_in_pits = 57;
-            Label labelPlus1LapTimeResultTest = new Label();
-            Label labelMinus1LapTimeResultTest = new Label();
+            Label labelPlus1LapTimeResultTest = new();
+            Label labelMinus1LapTimeResultTest = new();
 
             form.CalculateLapTimePlusMinus(labelPlus1LapTimeResultTest, labelMinus1LapTimeResultTest);
 
@@ -272,11 +270,11 @@ namespace FCalcACC.Tests
         [TestMethod("Calculating fuel for the race #1 (33 laps, full formation, 3,55 fpr)")]
         public void CalculateFuel_SampleData1()
         {
-            TextBox textBoxFuelPerLapTest = new TextBox() { Text = "3,55" };
-            ListBox listBoxformationLapTest = new ListBox() { Text = "Full" };
-            Label labelFuelRaceResultTest = new Label();
-            Label labelPlus1FuelResultTest = new Label();
-            Label labelMinus1FuelResultTest = new Label();
+            TextBox textBoxFuelPerLapTest = new() { Text = "3,55" };
+            ListBox listBoxformationLapTest = new() { Text = "Full" };
+            Label labelFuelRaceResultTest = new();
+            Label labelPlus1FuelResultTest = new();
+            Label labelMinus1FuelResultTest = new();
             form.number_of_laps = 33;
 
             form.CalculateFuel(textBoxFuelPerLapTest, listBoxformationLapTest, labelFuelRaceResultTest,
@@ -290,11 +288,11 @@ namespace FCalcACC.Tests
         [TestMethod("Calculating fuel for the race #2 (16 laps, short formation, 3.1 fpr)")]
         public void CalculateFuel_SampleData2()
         {
-            TextBox textBoxFuelPerLapTest = new TextBox() { Text = "3.,1" };
-            ListBox listBoxformationLapTest = new ListBox() { Text = "Short" };
-            Label labelFuelRaceResultTest = new Label();
-            Label labelPlus1FuelResultTest = new Label();
-            Label labelMinus1FuelResultTest = new Label();
+            TextBox textBoxFuelPerLapTest = new() { Text = "3.,1" };
+            ListBox listBoxformationLapTest = new() { Text = "Short" };
+            Label labelFuelRaceResultTest = new();
+            Label labelPlus1FuelResultTest = new();
+            Label labelMinus1FuelResultTest = new();
             form.number_of_laps = 16;
 
             form.CalculateFuel(textBoxFuelPerLapTest, listBoxformationLapTest, labelFuelRaceResultTest,
@@ -308,12 +306,11 @@ namespace FCalcACC.Tests
         [TestMethod("Calculating pit strategy #1 (0 pits)")]
         public void CalculatePitStops_SampleData1()
         {
-            Panel panelPitStopStrategyTest = new Panel();
-            Label labelFuelRaceResultTest = new Label() { Text = "56 L" };
-            ComboBox comboBoxPitOptionsTest = new ComboBox();
-            NumericUpDown numericUpDownPitsTest = new NumericUpDown();
-            numericUpDownPitsTest.Value = 0;
-            form.LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
+            Panel panelPitStopStrategyTest = new();
+            Label labelFuelRaceResultTest = new() { Text = "56 L" };
+            ComboBox comboBoxPitOptionsTest = new();
+            NumericUpDown numericUpDownPitsTest = new() { Value = 0 };
+            LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
             form.number_of_laps = 10;
             form.fuel_for_race_round_up = 56;
             form.fuel_per_lap = 5;
@@ -329,12 +326,11 @@ namespace FCalcACC.Tests
         [TestMethod("Calculating pit strategy #2 (3 pit, tires only)")]
         public void CalculatePitStops_SampleData2()
         {
-            Panel panelPitStopStrategyTest = new Panel();
-            Label labelFuelRaceResultTest = new Label();
-            ComboBox comboBoxPitOptionsTest = new ComboBox();
-            NumericUpDown numericUpDownPitsTest = new NumericUpDown();
-            numericUpDownPitsTest.Value = 3;
-            form.LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
+            Panel panelPitStopStrategyTest = new();
+            Label labelFuelRaceResultTest = new();
+            ComboBox comboBoxPitOptionsTest = new();
+            NumericUpDown numericUpDownPitsTest = new() { Value = 3 };
+            LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
             comboBoxPitOptionsTest.SelectedIndex = 2;
             form.number_of_laps = 20;
             form.fuel_for_race_round_up = 84;
@@ -361,12 +357,11 @@ namespace FCalcACC.Tests
         [TestMethod("Calculating pit strategy #3 (1 pit, 1L)")]
         public void CalculatePitStops_SampleData3()
         {
-            Panel panelPitStopStrategyTest = new Panel();
-            Label labelFuelRaceResultTest = new Label();
-            ComboBox comboBoxPitOptionsTest = new ComboBox();
-            NumericUpDown numericUpDownPitsTest = new NumericUpDown();
-            numericUpDownPitsTest.Value = 1;
-            form.LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
+            Panel panelPitStopStrategyTest = new();
+            Label labelFuelRaceResultTest = new();
+            ComboBox comboBoxPitOptionsTest = new();
+            NumericUpDown numericUpDownPitsTest = new() { Value = 1 };
+            LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
             comboBoxPitOptionsTest.SelectedIndex = 4;
             form.number_of_laps = 10;
             form.fuel_for_race_round_up = 44;
@@ -392,12 +387,11 @@ namespace FCalcACC.Tests
         [TestMethod("Calculating pit strategy #4 (5 pit, refuel+tires)")]
         public void CalculatePitStops_SampleData4()
         {
-            Panel panelPitStopStrategyTest = new Panel();
-            Label labelFuelRaceResultTest = new Label();
-            ComboBox comboBoxPitOptionsTest = new ComboBox();
-            NumericUpDown numericUpDownPitsTest = new NumericUpDown();
-            numericUpDownPitsTest.Value = 5;
-            form.LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
+            Panel panelPitStopStrategyTest = new();
+            Label labelFuelRaceResultTest = new();
+            ComboBox comboBoxPitOptionsTest = new();
+            NumericUpDown numericUpDownPitsTest = new() { Value = 5 };
+            LoadPitOptions(comboBoxPitOptionsTest, form.PIT_OPTIONS);
             comboBoxPitOptionsTest.SelectedIndex = 3;
             form.number_of_laps = 30;
             form.fuel_for_race_round_up = 124;


### PR DESCRIPTION
In pit strategy panel there are now numericUpDowns that let user change pit stop timing withing certain limits. When changes happens, fuel recalculation is done. 
Some small improvements to UI and calculations.
Code cleanup across whole solution.